### PR TITLE
fix compilation with g++, extern inline vs. static inline

### DIFF
--- a/filter.h
+++ b/filter.h
@@ -106,7 +106,7 @@ extern inline unsigned int lcm(unsigned int x, unsigned int y)
 /* ---------------------------------------------------------------------- */
 
 #ifndef __HAVE_ARCH_MAC
-extern inline float mac(const float *a, const float *b, unsigned int size)
+static inline float mac(const float *a, const float *b, unsigned int size)
 {
 	float sum = 0;
 	unsigned int i;
@@ -117,7 +117,7 @@ extern inline float mac(const float *a, const float *b, unsigned int size)
 }
 #endif /* __HAVE_ARCH_MAC */
 
-extern inline float fsqr(float f)
+static inline float fsqr(float f)
 {
         return f*f;
 }


### PR DESCRIPTION
Hi,

I have a problem build multimonNG in QtCreator, identifiet the problem and created a fix.

I fixed only what was immediate broken, there are other few lines with 'extern inline' whitch i left untouched.

'extern' and 'inline' cannot be combined (in g++ 4.7) together in this manner
and do not make sense either. Rather use 'static inline' which makes
the function inline, but does not export it in resulting *.o so no
symbol redefinition occurs.
