### PR TITLE
Allow compile-time culling of verbprintf() calls

### DIFF
--- a/multimon.h
+++ b/multimon.h
@@ -107,7 +107,7 @@ struct demod_state {
             uint32_t rx_data;
             struct l2_pocsag_rx rx[2];
         } pocsag;
-        
+
         struct l2_state_eas {
             char last_message[269];
             char msg_buf[4][269];
@@ -256,7 +256,12 @@ extern const struct demod_param demod_scope;
 
 /* ---------------------------------------------------------------------- */
 
-void verbprintf(int verb_level, const char *fmt, ...);
+void _verbprintf(int verb_level, const char *fmt, ...);
+#if !defined(MAX_VERBOSE_LEVEL)
+#   define MAX_VERBOSE_LEVEL 0
+#endif
+#define verbprintf(level, ...) \
+    do { if (level <= MAX_VERBOSE_LEVEL) _verbprintf(level, __VA_ARGS__); } while (0)
 
 void hdlc_init(struct demod_state *s);
 void hdlc_rxbit(struct demod_state *s, int bit);

--- a/multimonNG.pro
+++ b/multimonNG.pro
@@ -1,6 +1,7 @@
 TEMPLATE = app
 CONFIG += console
 CONFIG -= qt
+DEFINES += MAX_VERBOSE_LEVEL=1
 
 HEADERS += \
     multimon.h \

--- a/unixinput.c
+++ b/unixinput.c
@@ -82,7 +82,7 @@ void quit(void);
 
 /* ---------------------------------------------------------------------- */
 
-void verbprintf(int verb_level, const char *fmt, ...)
+void _verbprintf(int verb_level, const char *fmt, ...)
 {
     va_list args;
 
@@ -209,7 +209,7 @@ static void input_sound(unsigned int sample_rate, unsigned int overlap,
     /* Create the recording stream */
     if (!(s = pa_simple_new(NULL, "multimonNG", PA_STREAM_RECORD, NULL, "record", &ss, NULL, NULL, &error))) {
         fprintf(stderr, __FILE__": pa_simple_new() failed: %s\n", pa_strerror(error));
-        exit(4); 
+        exit(4);
     }
 
     for (;;) {
@@ -480,7 +480,7 @@ static const char usage_str[] = "multimonNG\n"
         "(C) 2012 by Elias Oenal\n\n"
         "Usage: %s [file] [file] [file] ...\n"
         "  If no [file] is given, input will be read from your default sound\n"
-        "  hardware. A filename of \"-\" denotes standard input.\n" 
+        "  hardware. A filename of \"-\" denotes standard input.\n"
         "  -t <type>  : input file type (any other type than raw requires sox)\n"
         "  -a <demod> : add demodulator\n"
         "  -s <demod> : subtract demodulator\n"


### PR DESCRIPTION
This introduces a new macro, `MAX_VERBOSE_LEVEL`, which culls all `verbprintf()` calls above that `verb_level` at compile time, so that they never make it into the compiled code at all. This allows you to separate the debug and production builds by making production builds have a 'verbosity cap' with what debug messages are available.

On x86 you can barely notice the performance difference from this, but on ARM (especially with old GCC), varargs stuff really sucks a lot, and just calling `verbprintf()` at all (even to return immediately) is actually very expensive.

I don't have any performance numbers for this one at the moment (gotta get access to the ARM board I was testing on again), but I can provide them if you want them as justification.
