### PR TITLE
patch to add correct handling of APRS, used for pymultimonaprs and other possible iGate software

### DIFF
--- a/unixinput.c
+++ b/unixinput.c
@@ -78,6 +78,7 @@ static unsigned int dem_mask[(NUMDEMOD+31)/32];
 
 static int verbose_level = 0;
 extern int pocsag_mode;
+extern int aprs_mode;
 void quit(void);
 
 /* ---------------------------------------------------------------------- */
@@ -489,6 +490,7 @@ static const char usage_str[] = "multimonNG\n"
         "  -v <level> : level of verbosity (for example '-v 10')\n"
         "  -f <mode>  : forces POCSAG data decoding as <mode> (<mode> can be 'numeric', 'alpha' and 'skyper')\n"
         "  -h         : this help\n"
+        "  -A         : APRS mode (TNC2 text output)\n"
         "   Raw input requires one channel, 16 bit, signed integer (platform-native)\n"
         "   samples at the demodulator's input sampling rate, which is\n"
         "   usually 22050 kHz. Raw input is assumed and required if piped input is used.\n";
@@ -511,7 +513,7 @@ int main(int argc, char *argv[])
     for (i = 0; i < NUMDEMOD; i++)
         fprintf(stderr, " %s", dem[i]->name);
     fprintf(stderr, "\n");
-    while ((c = getopt(argc, argv, "t:a:s:v:f:cqh")) != EOF) {
+    while ((c = getopt(argc, argv, "t:a:s:v:f:cqhA")) != EOF) {
         switch (c) {
         case 'h':
         case '?':
@@ -520,6 +522,17 @@ int main(int argc, char *argv[])
 
         case 'q':
             quietflg++;
+            break;
+
+        case 'A':
+            aprs_mode = 1;
+	    memset(dem_mask, 0, sizeof(dem_mask));
+            mask_first = 0;
+            for (i = 0; i < NUMDEMOD; i++)
+                if (!strcasecmp("AFSK1200", dem[i]->name)) {
+                    MASK_SET(i);
+                    break;
+                }
             break;
 
         case 'v':


### PR DESCRIPTION
This patch adds a new option to multimonNG, which outputs correct (TNC2 formatted) APRS packets, instead of raw AX.25 frames in AFSK1200 mode.

run with "multimonNG -A" to get APRS format output.

Example output:

```
APRS: DO1GL-5>APDR12,DO1GL*,WIDE2-2:=5111.11N/01111.11E$ http://aprsdroid.org/
```
