### PR TITLE
multimon-ng: added support for building with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,109 @@
+cmake_minimum_required( VERSION 2.8.8 )
+
+# The "MSVC" flag isn't set until the "project" command
+# is called.  Let's just check the operating system.
+if( NOT WIN32 )
+	project( multimon-ng C )
+else( NOT WIN32 )
+	# Visual Studio C compiler doesn't support C99 (i.e. stdbool.h);
+	# so use the Visual Studio C++ compiler instead
+	project( multimon-ng CXX )
+endif( NOT WIN32 )
+
+set( TARGET "${PROJECT_NAME}" )
+set( VERSION "1.0.0" )
+set( MAJOR "1" )
+set( MINOR "0" )
+set( PATCH "0" )
+
+if( WIN32 )
+	add_definitions( "-DWIN32_AUDIO" "-DONLY_RAW" "-DWINDOWS" )
+	link_libraries( ${TARGET} "-lwinmm" )
+	set( SOURCES ${SOURCES}
+		"win32_soundin.c"
+		)
+elseif( UNIX )
+	find_package( X11 )
+	if ( X11_FOUND )
+		option( X11_SUPPORT "Enable X11 display support" ${X11_FOUND} )
+		mark_as_advanced( X11_SUPPORT )
+	endif( X11_FOUND )
+	find_package( PulseAudio )
+	if ( PULSEAUDIO_FOUND )
+		option( PULSE_AUDIO_SUPPORT "Enable pulse audio support" ${PULSEAUDIO_FOUND} )
+		mark_as_advanced( PULSE_AUDIO_SUPPORT )
+	endif( PULSEAUDIO_FOUND )
+endif( WIN32 )
+
+if( X11_SUPPORT )
+	include_directories( ${X11_INCLUDE_DIR} )
+	link_libraries( ${X11_LIBRARIES} )
+	set( SOURCES ${SOURCES}
+		xdisplay.c
+		demod_display.c
+	)
+else( X11_SUPPORT )
+	add_definitions( "-DNO_X11" )
+endif( X11_SUPPORT ) 
+
+if( PULSE_AUDIO_SUPPORT )
+	include_directories( ${PULSEAUDIO_INCLUDE_DIR} )
+	link_libraries( ${PULSEAUDIO_LIBRARY} "-lpulse-simple" )
+	add_definitions( "-DPULSE_AUDIO" )
+else( PULSE_AUDIO_SUPPORT )
+	add_definitions( "-DDUMMY_AUDIO" )
+endif( PULSE_AUDIO_SUPPORT )
+
+if( NOT MSVC )
+	add_definitions( "-std=gnu99" )
+endif( NOT MSVC )
+add_definitions( "-DMAX_VERBOSE_LEVEL=3" "-DCHARSET_UTF8" )
+
+set( HEADERS ${HEADERS}
+    	multimon.h
+    	gen.h
+    	filter.h
+    	filter-i386.h
+	)
+
+set( SOURCES ${SOURCES}
+	unixinput.c
+	uart.c
+	pocsag.c
+	selcall.c
+	hdlc.c
+	demod_zvei1.c
+	demod_zvei2.c
+	demod_zvei3.c
+	demod_pzvei.c
+	demod_dzvei.c
+	demod_ccir.c
+	demod_eia.c
+	demod_eea.c
+	demod_ufsk12.c
+	demod_poc24.c
+	demod_poc12.c
+	demod_poc5.c
+	demod_hapn48.c
+	demod_fsk96.c
+	demod_dtmf.c
+	demod_clipfsk.c
+	demod_fmsfsk.c
+	demod_afsk24.c
+	demod_afsk24_3.c
+	demod_afsk24_2.c
+	demod_afsk12.c
+	costabi.c
+	costabf.c
+	clip.c
+	fms.c
+	demod_eas.c
+	demod_morse.c
+	demod_dumpcsv.c
+	)
+
+
+add_executable( "${TARGET}" ${SOURCES} ${HEADERS} )
+set_property(TARGET "${TARGET}" PROPERTY LINKER_LANGUAGE C)
+target_link_libraries( "${TARGET}" m )
+


### PR DESCRIPTION
Currently, multimon-ng builds with qmake.  However, this requires pulling in X11
packages in order to install.  Since multimon-ng is a console application the
requirement of X11 shouldn't be required.  The fix is to use cmake to build
the project.  This patch adds a CMakeLists.txt file in order to build the project.

The project was succesfully built on Mac OS (Darwin), Linux CentOS 7 with gcc and on
Microsoft Windows with Microsoft Visual Studio 2012.  The resulting program was ran
on Linux CentOS 7 and succesfully processes POCSAG512 messages.

To build without X11 support on Linux:
$ cmake -DX11_SUPPORT=OFF .
$ make

To build without Pulse Audio support on Linux:
$ cmake -DPULSE_AUDIO_SUPPORT=OFF .
$ make

Note that: X11 and Pulse Audio libraries aren't searched for on either Microsoft Windows or
Macintosh
