### PR TITLE
Fix FLEX pager demodulation on 32-bit targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set( VERSION "1.0.0" )
 set( MAJOR "1" )
 set( MINOR "0" )
 set( PATCH "0" )
+set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra" )
 
 if( WIN32 )
 	add_definitions( "-DWIN32_AUDIO" "-DONLY_RAW" "-DWINDOWS" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,12 @@ elseif( UNIX )
 		option( PULSE_AUDIO_SUPPORT "Enable pulse audio support" ${PULSEAUDIO_FOUND} )
 		mark_as_advanced( PULSE_AUDIO_SUPPORT )
 	endif( PULSEAUDIO_FOUND )
+
+	# Check if we can use the GCC/llvm __builtin_popcount
+	include( CheckCSourceCompiles )
+	check_c_source_compiles(
+		"int main() { __builtin_popcount(42); return 0; }" USE_BUILTIN_POPCOUNT )
+
 endif( WIN32 )
 
 if( X11_SUPPORT )

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -174,7 +174,19 @@ int is_tone_page(struct Flex * flex) {
 
 unsigned int count_bits(struct Flex * flex, unsigned int data) {
 	if (flex==NULL) return 0;
+#ifdef USE_BUILTIN_POPCOUNT
     return __builtin_popcount(data);
+#else
+    unsigned int n = (data >> 1) & 0x77777777;
+    data = data - n;
+    n = (n >> 1) & 0x77777777;
+    data = data - n;
+    n = (n >> 1) & 0x77777777;
+    data = data - n;
+    data = (data + (data >> 4)) & 0x0f0f0f0f;
+    data = data * 0x01010101;
+    return data >> 24;
+#endif
 }
 
 static int bch3121_fix_errors(struct Flex * flex, unsigned int * data_to_fix, char PhaseNo) {

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -151,14 +151,14 @@ struct Flex {
 };
 
 
-inline int is_alphanumeric_page(struct Flex * flex) {
+int is_alphanumeric_page(struct Flex * flex) {
 	if (flex==NULL) return 0;
 	return (flex->Decode.type == FLEX_PAGETYPE_ALPHANUMERIC ||
 			flex->Decode.type == FLEX_PAGETYPE_SECURE);
 }
 
 
-inline int is_numeric_page(struct Flex * flex) {
+int is_numeric_page(struct Flex * flex) {
 	if (flex==NULL) return 0;
 	return (flex->Decode.type == FLEX_PAGETYPE_STANDARD_NUMERIC ||
 			flex->Decode.type == FLEX_PAGETYPE_SPECIAL_NUMERIC  ||
@@ -166,7 +166,7 @@ inline int is_numeric_page(struct Flex * flex) {
 }
 
 
-inline int is_tone_page(struct Flex * flex) {
+int is_tone_page(struct Flex * flex) {
 	if (flex==NULL) return 0;
 	return (flex->Decode.type == FLEX_PAGETYPE_TONE);
 }

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -175,17 +175,17 @@ int is_tone_page(struct Flex * flex) {
 unsigned int count_bits(struct Flex * flex, unsigned int data) {
 	if (flex==NULL) return 0;
 #ifdef USE_BUILTIN_POPCOUNT
-    return __builtin_popcount(data);
+	return __builtin_popcount(data);
 #else
-    unsigned int n = (data >> 1) & 0x77777777;
-    data = data - n;
-    n = (n >> 1) & 0x77777777;
-    data = data - n;
-    n = (n >> 1) & 0x77777777;
-    data = data - n;
-    data = (data + (data >> 4)) & 0x0f0f0f0f;
-    data = data * 0x01010101;
-    return data >> 24;
+	unsigned int n = (data >> 1) & 0x77777777;
+	data = data - n;
+	n = (n >> 1) & 0x77777777;
+	data = data - n;
+	n = (n >> 1) & 0x77777777;
+	data = data - n;
+	data = (data + (data >> 4)) & 0x0f0f0f0f;
+	data = data * 0x01010101;
+	return data >> 24;
 #endif
 }
 


### PR DESCRIPTION
The current FLEX implementation used longs, and it seems it was only tested on a 64-bit target originally. This PR contains fixes for this, and tries to patch up use of unsigned long and unsigned long long (which is just aesthetic at this point) as c99 stdint types.

Tested on an x86_64 host and an ARMv7 host, and no regressions were found.