### PR TITLE
Adapting vehicle-id from dec to hex

### DIFF
--- a/fms.c
+++ b/fms.c
@@ -93,7 +93,7 @@ static void fms_disp_vehicle_id(uint16_t vehicle_id)
     uint8_t nib2 = (vehicle_id >> 8) & 0xF;
     uint8_t nib3 = (vehicle_id >> 12) & 0xF;
 
-    verbprintf(0, "FZG %1d%1d%1d%1d\t", nib0, nib1, nib2, nib3);
+    verbprintf(0, "FZG %1x%1x%1x%1x\t", nib0, nib1, nib2, nib3);
 }
 
 static void fms_disp_state(uint8_t state, uint8_t service_id, uint8_t direction)


### PR DESCRIPTION
Due to changes in local TR (RLP) there are hex-values allowed in the vehicle-id-field.
This change has no effect to existing installations as it only increases the number of available ids.