### PR TITLE
Updated POCSAG Alphanumeric special character values

### DIFF
--- a/pocsag.c
+++ b/pocsag.c
@@ -172,13 +172,13 @@ static char *translate_alpha(unsigned char chr)
                  { 0x7d, "\374" }, /* lower case u dieresis */
                  { 0x7e, "\337" }, /* sharp s */
              #elif defined CHARSET_UTF8
-                 { 0x5b, "Ä" }, /* upper case A dieresis */
-                 { 0x5c, "Ö" }, /* upper case O dieresis */
-                 { 0x5d, "Ü" }, /* upper case U dieresis */
-                 { 0x7b, "ä" }, /* lower case a dieresis */
-                 { 0x7c, "ö" }, /* lower case o dieresis */
-                 { 0x7d, "ü" }, /* lower case u dieresis */
-                 { 0x7e, "ß" }, /* sharp s */
+                 { 0x5b, "[" }, /* upper case A dieresis */
+                 { 0x5c, "\\" }, /* upper case O dieresis */
+                 { 0x5d, "]" }, /* upper case U dieresis */
+                 { 0x7b, "{" }, /* lower case a dieresis */
+                 { 0x7c, "|" }, /* lower case o dieresis */
+                 { 0x7d, "}" }, /* lower case u dieresis */
+                 { 0x7e, "~" }, /* sharp s */
              #else
                  { 0x5b, "[" }, /* upper case A dieresis */
                  { 0x5c, "\\" }, /* upper case O dieresis */

--- a/pocsag.c
+++ b/pocsag.c
@@ -180,13 +180,13 @@ static char *translate_alpha(unsigned char chr)
                  { 0x7d, "ü" }, /* lower case u dieresis */
                  { 0x7e, "ß" }, /* sharp s */
              #else
-                 { 0x5b, "AE" }, /* upper case A dieresis */
-                 { 0x5c, "OE" }, /* upper case O dieresis */
-                 { 0x5d, "UE" }, /* upper case U dieresis */
-                 { 0x7b, "ae" }, /* lower case a dieresis */
-                 { 0x7c, "oe" }, /* lower case o dieresis */
-                 { 0x7d, "ue" }, /* lower case u dieresis */
-                 { 0x7e, "ss" }, /* sharp s */
+                 { 0x5b, "[" }, /* upper case A dieresis */
+                 { 0x5c, "\\" }, /* upper case O dieresis */
+                 { 0x5d, "]" }, /* upper case U dieresis */
+                 { 0x7b, "{" }, /* lower case a dieresis */
+                 { 0x7c, "|" }, /* lower case o dieresis */
+                 { 0x7d, "}" }, /* lower case u dieresis */
+                 { 0x7e, "~" }, /* sharp s */
              #endif
                  { 127, "<DEL>" }};
 


### PR DESCRIPTION
Corrected the values of 0x5b, 0x5c, 0x5d, 7b, 7c, 7d, 7e to be the correct special character. Got the info from the NZ Telepermit for pagers (www.telepermit.co.nz/PTC251.pdf).