### PR TITLE
Comment out includes for sys/wait and sys/resource

### DIFF
--- a/demod_x10.c
+++ b/demod_x10.c
@@ -19,9 +19,9 @@
 
 #include "multimon.h"
 #include <sys/types.h>
-#include <sys/wait.h>
+//#include <sys/wait.h>
 #include <sys/time.h>
-#include <sys/resource.h>
+//#include <sys/resource.h>
 #include <signal.h>
 #include <math.h>
 #include <string.h>


### PR DESCRIPTION
Comment out both the above includes as they cause compile errors on Windows, does not seem to cause any issues running the program afterwards, issue #96 