### PR TITLE
Fix event polling loop in SCOPE demodulator

### DIFF
--- a/xdisplay.c
+++ b/xdisplay.c
@@ -114,7 +114,8 @@ static char *x_getkey(void)
 
 	if (!display)
 		return NULL;
-	while (XNextEvent(display, &evt) == 0) {
+	while (XCheckWindowEvent(display, window, KeyPressMask |
+				StructureNotifyMask | ExposureMask, &evt)) {
 		switch (evt.type) {
 		case KeyPress:
 			i = XLookupString((XKeyEvent *)&evt, kbuf, 


### PR DESCRIPTION
XNextEvent blocks while no events are available. The first time
the child display process enters process_keystrokes(), it loops
forever inside x_getkey() and never gets to update the display.

This changes XNextEvent to XCheckWindowEvent, which does
not block.