### PR TITLE
Restore FSF copyright notices on win32_getopt.[ch]

### DIFF
--- a/win32_getopt.c
+++ b/win32_getopt.c
@@ -1,3 +1,26 @@
+/* Getopt for GNU.
+   NOTE: getopt is part of the C library, so if you don't know what
+   "Keep this file name-space clean" means, talk to drepper@gnu.org
+   before changing it!
+   Copyright (C) 1987-1996,1998-2004,2008,2009,2010
+   Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, write to the Free
+   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307 USA.  */
+
 /* Getopt for Microsoft C  
 This code is a modification of the Free Software Foundation, Inc. 
 Getopt library for parsing command line argument the purpose was

--- a/win32_getopt.h
+++ b/win32_getopt.h
@@ -1,3 +1,23 @@
+/* Declarations for getopt.
+   Copyright (C) 1989-1994,1996-1999,2001,2003,2004,2009
+   Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, write to the Free
+   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+   02111-1307 USA.  */
+
 /* Getopt for Microsoft C  
 This code is a modification of the Free Software Foundation, Inc. 
 Getopt library for parsing command line argument the purpose was


### PR DESCRIPTION
This restores the FSF copyright notice that had disappeared from this port of getopt. All changes done for the port could easily be done by machine, so the FSF likely holds the sole copyright on these files. Please consider merging.