### PR TITLE
Compare function codes and don't penalise NUL

### DIFF
--- a/pocsag.c
+++ b/pocsag.c
@@ -218,7 +218,7 @@ static char *translate_alpha(unsigned char chr)
 /* ---------------------------------------------------------------------- */
 static int guesstimate_alpha(const unsigned char cp)
 {
-    if(cp < 32 || cp == 127)
+    if((cp > 0 && cp < 32) || cp == 127)
         return -5; // Non printable characters are uncommon
     else if((cp > 32 && cp < 48)
             || (cp > 57 && cp < 65)
@@ -401,20 +401,22 @@ static void pocsag_printmessage(struct demod_state *s, bool sync)
             int guess_alpha = 0;
             int guess_skyper = 0;
             int unsure = 0;
+						int func = 0;
 
             guess_num = print_msg_numeric(&s->l2.pocsag, num_string, sizeof(num_string));
             guess_alpha = print_msg_alpha(&s->l2.pocsag, alpha_string, sizeof(alpha_string));
             guess_skyper = print_msg_skyper(&s->l2.pocsag, skyper_string, sizeof(skyper_string));
 
-            if(guess_num < 20 && guess_alpha < 20 && guess_skyper < 20)
+						func = s->l2.pocsag.function;
+
+            if(guess_alpha < 20 && guess_skyper < 20)
             {
                 if(pocsag_heuristic_pruning)
                     return;
                 unsure = 1;
             }
 
-
-            if((pocsag_mode == POCSAG_MODE_NUMERIC) || ((pocsag_mode == POCSAG_MODE_AUTO) && (guess_num >= 20 || unsure)))
+            if((pocsag_mode == POCSAG_MODE_NUMERIC) || ((pocsag_mode == POCSAG_MODE_AUTO) && func == 0 ))
             {
                 if((s->l2.pocsag.address != -2) || (s->l2.pocsag.function != -2))
                     verbprintf(0, "%s: Address: %7lu  Function: %1hhi  ",s->dem_par->name,
@@ -428,7 +430,7 @@ static void pocsag_printmessage(struct demod_state *s, bool sync)
                 verbprintf(0,"\n");
             }
 
-            if((pocsag_mode == POCSAG_MODE_ALPHA) || ((pocsag_mode == POCSAG_MODE_AUTO) && (guess_alpha >= 20 || unsure)))
+            if((pocsag_mode == POCSAG_MODE_ALPHA) || ((pocsag_mode == POCSAG_MODE_AUTO) && func == 3 && (guess_alpha >= guess_skyper || unsure)))
             {
                 if((s->l2.pocsag.address != -2) || (s->l2.pocsag.function != -2))
                     verbprintf(0, "%s: Address: %7lu  Function: %1hhi  ",s->dem_par->name,
@@ -442,7 +444,7 @@ static void pocsag_printmessage(struct demod_state *s, bool sync)
                 verbprintf(0,"\n");
             }
 
-            if((pocsag_mode == POCSAG_MODE_SKYPER) || ((pocsag_mode == POCSAG_MODE_AUTO) && (guess_skyper >= 20 || unsure)))
+						if((pocsag_mode == POCSAG_MODE_SKYPER) || ((pocsag_mode == POCSAG_MODE_AUTO) && func == 3 && (guess_skyper >= guess_alpha || unsure)))
             {
                 if((s->l2.pocsag.address != -2) || (s->l2.pocsag.function != -2))
                     verbprintf(0, "%s: Address: %7lu  Function: %1hhi  ",s->dem_par->name,


### PR DESCRIPTION
POCSAG tells you whether a msg is numeric or alphanumeric with the function code (0=num, 3=alpha)

The only decision to make is if an alpha msg is plain or skyper!, but we don't want to penalise NUL characters (some systems pad with NUL!)

It's not an exact science yet, but it does a slightly better job now!