### PR TITLE
Compare function codes and don't penalise NUL

### DIFF
--- a/multimon.h
+++ b/multimon.h
@@ -46,10 +46,11 @@ extern const float costabf[0x400];
 
 enum
 {
-    POCSAG_MODE_AUTO = 0,
+    POCSAG_MODE_STANDARD = 0,
     POCSAG_MODE_NUMERIC = 1,
     POCSAG_MODE_ALPHA = 2,
     POCSAG_MODE_SKYPER = 3,
+    POCSAG_MODE_AUTO = 4,
 };
 
 enum EAS_L2_State

--- a/pocsag.c
+++ b/pocsag.c
@@ -430,7 +430,7 @@ static void pocsag_printmessage(struct demod_state *s, bool sync)
                 verbprintf(0,"\n");
             }
 
-            if((pocsag_mode == POCSAG_MODE_ALPHA) || ((pocsag_mode == POCSAG_MODE_AUTO) && func == 3 && (guess_alpha >= guess_skyper || unsure)))
+            if((pocsag_mode == POCSAG_MODE_ALPHA) || ((pocsag_mode == POCSAG_MODE_AUTO) && func != 0 && (guess_alpha >= guess_skyper || unsure)))
             {
                 if((s->l2.pocsag.address != -2) || (s->l2.pocsag.function != -2))
                     verbprintf(0, "%s: Address: %7lu  Function: %1hhi  ",s->dem_par->name,
@@ -444,7 +444,7 @@ static void pocsag_printmessage(struct demod_state *s, bool sync)
                 verbprintf(0,"\n");
             }
 
-            if((pocsag_mode == POCSAG_MODE_SKYPER) || ((pocsag_mode == POCSAG_MODE_AUTO) && func == 3 && (guess_skyper >= guess_alpha || unsure)))
+            if((pocsag_mode == POCSAG_MODE_SKYPER) || ((pocsag_mode == POCSAG_MODE_AUTO) && func != 0 && (guess_skyper >= guess_alpha || unsure)))
             {
                 if((s->l2.pocsag.address != -2) || (s->l2.pocsag.function != -2))
                     verbprintf(0, "%s: Address: %7lu  Function: %1hhi  ",s->dem_par->name,

--- a/pocsag.c
+++ b/pocsag.c
@@ -409,7 +409,7 @@ static void pocsag_printmessage(struct demod_state *s, bool sync)
 
             func = s->l2.pocsag.function;
 
-            if(guess_alpha < 20 && guess_skyper < 20)
+            if(guess_num < 20 && guess_alpha < 20 && guess_skyper < 20)
             {
                 if(pocsag_heuristic_pruning)
                     return;

--- a/pocsag.c
+++ b/pocsag.c
@@ -218,7 +218,7 @@ static char *translate_alpha(unsigned char chr)
 /* ---------------------------------------------------------------------- */
 static int guesstimate_alpha(const unsigned char cp)
 {
-    if(cp < 32 || cp == 127)
+    if((cp > 0 && cp < 32) || cp == 127)
         return -5; // Non printable characters are uncommon
     else if((cp > 32 && cp < 48)
             || (cp > 57 && cp < 65)
@@ -401,20 +401,22 @@ static void pocsag_printmessage(struct demod_state *s, bool sync)
             int guess_alpha = 0;
             int guess_skyper = 0;
             int unsure = 0;
+            int func = 0;
 
             guess_num = print_msg_numeric(&s->l2.pocsag, num_string, sizeof(num_string));
             guess_alpha = print_msg_alpha(&s->l2.pocsag, alpha_string, sizeof(alpha_string));
             guess_skyper = print_msg_skyper(&s->l2.pocsag, skyper_string, sizeof(skyper_string));
 
-            if(guess_num < 20 && guess_alpha < 20 && guess_skyper < 20)
+            func = s->l2.pocsag.function;
+
+            if(guess_alpha < 20 && guess_skyper < 20)
             {
                 if(pocsag_heuristic_pruning)
                     return;
                 unsure = 1;
             }
 
-
-            if((pocsag_mode == POCSAG_MODE_NUMERIC) || ((pocsag_mode == POCSAG_MODE_AUTO) && (guess_num >= 20 || unsure)))
+            if((pocsag_mode == POCSAG_MODE_NUMERIC) || ((pocsag_mode == POCSAG_MODE_AUTO) && func == 0 ))
             {
                 if((s->l2.pocsag.address != -2) || (s->l2.pocsag.function != -2))
                     verbprintf(0, "%s: Address: %7lu  Function: %1hhi  ",s->dem_par->name,
@@ -428,7 +430,7 @@ static void pocsag_printmessage(struct demod_state *s, bool sync)
                 verbprintf(0,"\n");
             }
 
-            if((pocsag_mode == POCSAG_MODE_ALPHA) || ((pocsag_mode == POCSAG_MODE_AUTO) && (guess_alpha >= 20 || unsure)))
+            if((pocsag_mode == POCSAG_MODE_ALPHA) || ((pocsag_mode == POCSAG_MODE_AUTO) && func == 3 && (guess_alpha >= guess_skyper || unsure)))
             {
                 if((s->l2.pocsag.address != -2) || (s->l2.pocsag.function != -2))
                     verbprintf(0, "%s: Address: %7lu  Function: %1hhi  ",s->dem_par->name,
@@ -442,7 +444,7 @@ static void pocsag_printmessage(struct demod_state *s, bool sync)
                 verbprintf(0,"\n");
             }
 
-            if((pocsag_mode == POCSAG_MODE_SKYPER) || ((pocsag_mode == POCSAG_MODE_AUTO) && (guess_skyper >= 20 || unsure)))
+            if((pocsag_mode == POCSAG_MODE_SKYPER) || ((pocsag_mode == POCSAG_MODE_AUTO) && func == 3 && (guess_skyper >= guess_alpha || unsure)))
             {
                 if((s->l2.pocsag.address != -2) || (s->l2.pocsag.function != -2))
                     verbprintf(0, "%s: Address: %7lu  Function: %1hhi  ",s->dem_par->name,

--- a/pocsag.c
+++ b/pocsag.c
@@ -57,7 +57,7 @@
 #define POSCAG
 /* ---------------------------------------------------------------------- */
 
-int pocsag_mode = 0;
+int pocsag_mode = POCSAG_MODE_STANDARD;
 int pocsag_invert_input = 0;
 int pocsag_error_correction = 2;
 int pocsag_show_partial_decodes = 0;
@@ -416,7 +416,7 @@ static void pocsag_printmessage(struct demod_state *s, bool sync)
                 unsure = 1;
             }
 
-            if((pocsag_mode == POCSAG_MODE_NUMERIC) || ((pocsag_mode == POCSAG_MODE_AUTO) && func == 0 ))
+            if((pocsag_mode == POCSAG_MODE_NUMERIC) || ((pocsag_mode == POCSAG_MODE_STANDARD) && (func == 0)) || ((pocsag_mode == POCSAG_MODE_AUTO) && (guess_num >= 20 || unsure)))
             {
                 if((s->l2.pocsag.address != -2) || (s->l2.pocsag.function != -2))
                     verbprintf(0, "%s: Address: %7lu  Function: %1hhi  ",s->dem_par->name,
@@ -430,7 +430,7 @@ static void pocsag_printmessage(struct demod_state *s, bool sync)
                 verbprintf(0,"\n");
             }
 
-            if((pocsag_mode == POCSAG_MODE_ALPHA) || ((pocsag_mode == POCSAG_MODE_AUTO) && func != 0 && (guess_alpha >= guess_skyper || unsure)))
+            if((pocsag_mode == POCSAG_MODE_ALPHA) || ((pocsag_mode == POCSAG_MODE_STANDARD) && (func != 0)) || ((pocsag_mode == POCSAG_MODE_AUTO) && (guess_alpha >= guess_skyper || unsure)))
             {
                 if((s->l2.pocsag.address != -2) || (s->l2.pocsag.function != -2))
                     verbprintf(0, "%s: Address: %7lu  Function: %1hhi  ",s->dem_par->name,
@@ -444,7 +444,7 @@ static void pocsag_printmessage(struct demod_state *s, bool sync)
                 verbprintf(0,"\n");
             }
 
-            if((pocsag_mode == POCSAG_MODE_SKYPER) || ((pocsag_mode == POCSAG_MODE_AUTO) && func != 0 && (guess_skyper >= guess_alpha || unsure)))
+            if((pocsag_mode == POCSAG_MODE_SKYPER) || ((pocsag_mode == POCSAG_MODE_AUTO) && (guess_skyper >= guess_alpha || unsure))) // Only output SKYPER if we're explicitly asking for it or we're auto guessing! (because it's not part of one of the standards, right?!)
             {
                 if((s->l2.pocsag.address != -2) || (s->l2.pocsag.function != -2))
                     verbprintf(0, "%s: Address: %7lu  Function: %1hhi  ",s->dem_par->name,

--- a/unixinput.c
+++ b/unixinput.c
@@ -576,8 +576,8 @@ static const char usage_str[] = "\n"
         "  -u         : POCSAG: Heuristically prune unlikely decodes.\n"
         "  -i         : POCSAG: Inverts the input samples. Try this if decoding fails.\n"
         "  -p         : POCSAG: Show partially received messages.\n"
-        "  -f <mode>  : POCSAG: Disables auto-detection and forces decoding of data as <mode>\n"
-        "                       (<mode> can be 'numeric', 'alpha' and 'skyper')\n"
+        "  -f <mode>  : POCSAG: Overrides standards and forces decoding of data as <mode>\n"
+        "                       (<mode> can be 'numeric', 'alpha', 'skyper' or 'auto')\n"
         "  -b <level> : POCSAG: BCH bit error correction level. Set 0 to disable, default is 2.\n"
         "                       Lower levels increase performance and lower false positives.\n"
         "  -o         : CW: Set threshold for dit detection (default: 500)\n"
@@ -727,6 +727,8 @@ intypefound:
                     pocsag_mode = POCSAG_MODE_ALPHA;
                 else if(!strncmp("skyper",optarg, sizeof("skyper")))
                     pocsag_mode = POCSAG_MODE_SKYPER;
+                else if(!strncmp("auto",optarg, sizeof("auto")))
+                    pocsag_mode = POCSAG_MODE_AUTO;
             }else fprintf(stderr, "a POCSAG mode has already been selected!\n");
             break;
             


### PR DESCRIPTION
POCSAG tells you whether a msg is numeric or alphanumeric with the function code (0=num, 3=alpha)

The only decision to make is if an alpha msg is plain or skyper!, but we don't want to penalise NUL characters (some systems pad with NUL!)

It's not an exact science yet, but it does a slightly better job now!