### PR TITLE
Restore BCH copyright notice and add a decoder stub

### DIFF
--- a/BCHCode.c
+++ b/BCHCode.c
@@ -1,4 +1,52 @@
 /*
+ * File:    bch3121.c
+ * Author:  Robert Morelos-Zaragoza
+ *
+ * %%%%%%%%%%% Encoder/Decoder for a (31,21,5) binary BCH code %%%%%%%%%%%%%
+ *
+ *	This code is used in the POCSAG protocol specification for pagers.
+ *
+ *	In this specific case, there is no need to use the Berlekamp-Massey
+ *	algorithm, since the error locator polynomial is of at most degree 2.
+ *	Instead, we simply solve by hand two simultaneous equations to give
+ * 	the coefficients of the error locator polynomial in the case of two
+ *	errors. In the case of one error, the location is given by the first
+ *	syndrome.
+ *
+ *	This program derivates from the original bch2.c, which was written
+ *	to simulate the encoding/decoding of primitive binary BCH codes.
+ *	Part of this program is adapted from a Reed-Solomon encoder/decoder
+ *	program,  'rs.c', to the binary case.
+ *
+ *	rs.c by Simon Rockliff, University of Adelaide, 21/9/89
+ *	bch2.c by Robert Morelos-Zaragoza, University of Hawaii, 5/19/92
+ *
+ * COPYRIGHT NOTICE: This computer program is free for non-commercial purposes.
+ * You may implement this program for any non-commercial application. You may
+ * also implement this program for commercial purposes, provided that you
+ * obtain my written permission. Any modification of this program is covered
+ * by this copyright.
+ *
+ * %%%% Copyright 1994 (c) Robert Morelos-Zaragoza. All rights reserved. %%%%%
+ *
+ * m = order of the field GF(2**5) = 5
+ * n = 2**5 - 1 = 31 = length
+ * t = 2 = error correcting capability
+ * d = 2*t + 1 = 5 = designed minimum distance
+ * k = n - deg(g(x)) = 21 = dimension
+ * p[] = coefficients of primitive polynomial used to generate GF(2**5)
+ * g[] = coefficients of generator polynomial, g(x)
+ * alpha_to [] = log table of GF(2**5)
+ * index_of[] = antilog table of GF(2**5)
+ * data[] = coefficients of data polynomial, i(x)
+ * bb[] = coefficients of redundancy polynomial ( x**(10) i(x) ) modulo g(x)
+ * numerr = number of errors
+ * errpos[] = error positions
+ * recd[] = coefficients of received polynomial
+ * decerror = number of decoding errors (in MESSAGE positions)
+ *
+ */
+/*
  *      BCHCode.c
  *
  *      Copyright (C) 2015 Craig Shelley (craig@microtron.org.uk)

--- a/BCHCode_stub.c
+++ b/BCHCode_stub.c
@@ -1,0 +1,50 @@
+/*
+ *      BCHCode_stub.c
+ *
+ *      Copyright (C) 2018 Göran Weinholt <weinholt@debian.org>
+ *
+ *      Stub replacement for BCHCode.c, whose license is GPL incompatible
+ *
+ *      This program is free software; you can redistribute it and/or modify
+ *      it under the terms of the GNU General Public License as published by
+ *      the Free Software Foundation; either version 2 of the License, or
+ *      (at your option) any later version.
+ *
+ *      This program is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License along
+ *      with this program; if not, write to the Free Software Foundation, Inc.,
+ *      51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <stdlib.h>
+#include "BCHCode.h"
+
+struct BCHCode {
+};
+
+struct BCHCode *BCHCode_New(int p[], int m, int n, int k, int t)
+{
+    /* Ignore unused variables */
+    (void) p;
+    (void) m;
+    (void) n;
+    (void) k;
+    (void) t;
+    return malloc(sizeof(struct BCHCode));
+}
+
+void BCHCode_Delete(struct BCHCode *BCHCode_data)
+{
+    free(BCHCode_data);
+}
+
+int BCHCode_Decode(struct BCHCode *BCHCode_data, int recd[])
+{
+    (void) BCHCode_data;
+    (void) recd;
+    return 0;
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,15 @@ if( NOT MSVC )
 endif( NOT MSVC )
 add_definitions( "-DMAX_VERBOSE_LEVEL=3" "-DCHARSET_UTF8" )
 
+if ( EXISTS "${multimon-ng_SOURCE_DIR}/BCHCode.c" )
+	set( SOURCES ${SOURCES}
+		BCHCode.c )
+else()
+	message(STATUS "Using the BCH decoder stub")
+	set( SOURCES ${SOURCES}
+		BCHCode_stub.c )
+endif()
+
 set( HEADERS ${HEADERS}
     	multimon.h
     	gen.h
@@ -102,7 +111,6 @@ set( SOURCES ${SOURCES}
 	demod_afsk24_2.c
 	demod_afsk12.c
 	demod_flex.c
-	BCHCode.c
 	costabi.c
 	costabf.c
 	clip.c


### PR DESCRIPTION
Please review these commits that restore Robert Morelos-Zaragoza's copyright notice and adds a stub that is automatically used when BCHCode.c is missing.

I've tested the code with the two FLEX samples from issue #1.

If these changes are acceptable then I can continue packaging multimon-ng for Debian and simply remove BCHCode.c when I repack the tarball. It would make things easier for me if you also make a new release.