### PR TITLE
filter false positive DTMF detections

### DIFF
--- a/demod_dtmf.c
+++ b/demod_dtmf.c
@@ -114,6 +114,10 @@ static inline int process_block(struct demod_state *s)
 		return -1;
 	if ((tote * 0.4) > (totte[i] + totte[j+4]))
 		return -1;
+	if (totte[i]*3.0<totte[j+4])
+		return -1;
+	if (totte[j+4]*3.0<totte[i])
+		return -1;
 	return (i & 3) | ((j << 2) & 0xc);
 }
 


### PR DESCRIPTION
During some testing I found out that (with my setup) non DTMF sounds (general city sound, car traffic, police siren, women screaming, ...) could trigger the detection. After some investigation I found out that  the difference between a valid and invalid detection could be simply made.
The enhancement I made is to check if the energy levels of the 2 detected frequencies is about the same (in a 300% range).
A DTMF is generated with 2 frequencies of the same energy level. So that is also what should be detected. 

In the non DTMF sound I used, most of the detection where of 2 frequencies that were in the range of 50000%.