### PR TITLE
Update demod_flex.c

### DIFF
--- a/demod_flex.c
+++ b/demod_flex.c
@@ -625,9 +625,7 @@ static void parse_numeric(struct Flex * flex, unsigned int * phaseptr, char Phas
 			}
 			dw >>= 1;
 			if(--count == 0) {
-				if(digit != 0x0C) {// Fill
-					verbprintf(0, "%c", flex_bcd[digit]);
-				}
+				verbprintf(0, "%c", flex_bcd[digit]);
 				count = 4;
 			}
 		}


### PR DESCRIPTION
The South Australian Government Radio Network paging system sends numeric messages that are phone numbers with spaces for readability e.g.  "0123 456 789".   A hardware based decoder will not strip these spaces, so neither should multimode-ng
