### PR TITLE
Added option to output FMSFSK packets just as hex and crc

### DIFF
--- a/fms.c
+++ b/fms.c
@@ -25,6 +25,10 @@
 
 /* ---------------------------------------------------------------------- */
 
+bool fms_justhex = false;
+
+/* ---------------------------------------------------------------------- */
+
 static void fms_disp_service_id(uint8_t service_id)
 {
     verbprintf(0, "%1x=", service_id);
@@ -261,33 +265,38 @@ static void fms_disp_packet(uint64_t message)
 
     fms_print_message_hex(message);
 
-    verbprintf(0, "FMS: %08x%04x (", message >> 32, ((uint32_t)message >> 16));
+    verbprintf(0, "FMS: %08x%04x", message >> 32, ((uint32_t)message >> 16));
 
-    service_id = (message >> 16) & 0xF;
-    fms_disp_service_id(service_id);
+    if(!fms_justhex)
+    {
+        verbprintf(0, " (");
+        service_id = (message >> 16) & 0xF;
+        fms_disp_service_id(service_id);
 
-    state_id = (message >> 20) & 0xF;
-    loc_id = (message >> 24) & 0xFF;
-    fms_disp_state_id(state_id, loc_id);
-    fms_disp_loc_id(loc_id);
+        state_id = (message >> 20) & 0xF;
+        loc_id = (message >> 24) & 0xFF;
+        fms_disp_state_id(state_id, loc_id);
+        fms_disp_loc_id(loc_id);
 
-    vehicle_id = (message >> 32) & 0xFFFF;
-    fms_disp_vehicle_id(vehicle_id);
+        vehicle_id = (message >> 32) & 0xFFFF;
+        fms_disp_vehicle_id(vehicle_id);
 
-    state = (message >> 48) & 0xF;
+        state = (message >> 48) & 0xF;
 
-    //model = (message >> 52) & 0x1;
-    direction = (message >> 53) & 0x1;
-    fms_disp_state(state, direction);
+        //model = (message >> 52) & 0x1;
+        direction = (message >> 53) & 0x1;
+        fms_disp_state(state, direction);
 
-    fms_disp_direction(direction);
+        fms_disp_direction(direction);
 
-    short_info = (message >> 54) & 0x3;
-    fms_disp_shortinfo(short_info);
+        short_info = (message >> 54) & 0x3;
+        fms_disp_shortinfo(short_info);
 
-    crc = (message >> 55) & 0x3F;
+        crc = (message >> 55) & 0x3F;
 
-    verbprintf(0, ") ");
+        verbprintf(0, ") ");
+    }
+    else verbprintf(0, " ");
 
     if (fms_is_crc_correct(message))
     {
@@ -297,10 +306,8 @@ static void fms_disp_packet(uint64_t message)
             verbprintf(0, " AFTER SWAPPING ONE BIT");
         }
     }
-    else
-    {
-        verbprintf(0, "CRC INCORRECT (%x)", crc);
-    }
+    else verbprintf(0, "CRC INCORRECT (%x)", crc);
+    
     verbprintf(0, "\n");
 }
 

--- a/unixinput.c
+++ b/unixinput.c
@@ -580,7 +580,7 @@ static const char usage_str[] = "\n"
         "  -m         : Mute SoX warnings\n"
         "  -r         : Call SoX in repeatable mode (e.g. fixed random seed for dithering)\n"
         "  -n         : Don't flush stdout, increases performance.\n"
-	"  -j         : FMS: Just output hex data and CRC, no parsing.\n"
+        "  -j         : FMS: Just output hex data and CRC, no parsing.\n"
         "  -e         : POCSAG: Hide empty messages.\n"
         "  -u         : POCSAG: Heuristically prune unlikely decodes.\n"
         "  -i         : POCSAG: Inverts the input samples. Try this if decoding fails.\n"
@@ -671,8 +671,8 @@ int main(int argc, char *argv[])
         case 'm':
             mute_sox = 1;
             break;
-	
-	case 'j':
+
+        case 'j':
             fms_justhex = true;
             break;
             

--- a/unixinput.c
+++ b/unixinput.c
@@ -93,6 +93,8 @@ static bool is_startline = true;
 static int timestamp = 0;
 static char *label = NULL;
 
+extern bool fms_justhex;
+
 extern int pocsag_mode;
 extern int pocsag_invert_input;
 extern int pocsag_error_correction;
@@ -578,6 +580,7 @@ static const char usage_str[] = "\n"
         "  -m         : Mute SoX warnings\n"
         "  -r         : Call SoX in repeatable mode (e.g. fixed random seed for dithering)\n"
         "  -n         : Don't flush stdout, increases performance.\n"
+	"  -j         : FMS: Just output hex data and CRC, no parsing.\n"
         "  -e         : POCSAG: Hide empty messages.\n"
         "  -u         : POCSAG: Heuristically prune unlikely decodes.\n"
         "  -i         : POCSAG: Inverts the input samples. Try this if decoding fails.\n"
@@ -618,7 +621,7 @@ int main(int argc, char *argv[])
         {0, 0, 0, 0}
       };
 
-    while ((c = getopt_long(argc, argv, "t:a:s:v:b:f:g:d:o:cqhAmrxynipeuC:", long_options, NULL)) != EOF) {
+    while ((c = getopt_long(argc, argv, "t:a:s:v:f:b:C:o:d:g:cqhAmrnjeuipxy", long_options, NULL)) != EOF) {
         switch (c) {
         case 'h':
         case '?':
@@ -667,6 +670,10 @@ int main(int argc, char *argv[])
             
         case 'm':
             mute_sox = 1;
+            break;
+	
+	case 'j':
+            fms_justhex = true;
             break;
             
         case 'r':


### PR DESCRIPTION
Added option to just output the fms hex data. Many programs are parsing stdout from multimon-ng. Depending on application, leaving out the additional info increases performance and makes parsing easier.