### PR TITLE
Remove the use of __FILE__ to fix build reproducibility

### DIFF
--- a/unixinput.c
+++ b/unixinput.c
@@ -274,7 +274,7 @@ static void input_sound(unsigned int sample_rate, unsigned int overlap,
     
     /* Create the recording stream */
     if (!(s = pa_simple_new(NULL, "multimon-ng", PA_STREAM_RECORD, NULL, "record", &ss, NULL, NULL, &error))) {
-        fprintf(stderr, __FILE__": pa_simple_new() failed: %s\n", pa_strerror(error));
+        fprintf(stderr, "unixinput.c: pa_simple_new() failed: %s\n", pa_strerror(error));
         exit(4);
     }
     


### PR DESCRIPTION
Automatic reproducibility tests in Debian found that the multimon-ng binary contained the filename of the directory it was built in. Please accept this small change to make the binary reproducible.