### PR TITLE
139 characters missing from flex

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,15 @@
+name: C/C++ CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: cmake
+      run: mkdir build && cd build && cmake ..
+    - name: make
+      run: make

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -12,4 +12,4 @@ jobs:
     - name: cmake
       run: mkdir build && cd build && cmake ..
     - name: make
-      run: make
+      run: cd build && make

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ Icon?
 ehthumbs.db
 Thumbs.db
 *.bak
+
+# Tool cache #
+##############
+*.sw[op]

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -124,7 +124,8 @@
 // there are at most 88 words per frame's phase buffer of a page
 //   but at least 1 BIW 1 AW 1 VW, so max 85 data words (dw) for text
 // each dw is 3 chars of 7b ASCII (21 bits of text, 11 bits of checksum)
-#define MAX_ALN              256           // max possible ALN characters
+// this is 256, BUT each char could need to be escaped (%, \n, \r, \t), so double it
+#define MAX_ALN              512           // max possible ALN characters
 
 
 enum Flex_PageTypeEnum {

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -805,12 +805,15 @@ static void decode_phase(struct Flex * flex, char PhaseNo) {
     flex->Decode.long_address = (aiw < 0x8001L) ||
       (aiw > 0x1E0000L && aiw < 0x1F0001L) ||
       (aiw > 0x1F7FFEL);
-    flex->Decode.capcode = aiw - 0x8000L;
-
-    if (flex->Decode.long_address)
-    {
-      verbprintf(4, "FLEX: Found 'Long Address' bit, ignoring as I think this is handled incorrectly at the moment issue#79\n");
-      // i++;
+    flex->Decode.capcode = aiw - 0x8000L;  // when short address
+    if (flex->Decode.long_address) {
+      // Couldn't find spec on this, credit to PDW
+      flex->Decode.capcode = phaseptr[i + 1] ^ 0x1FFFFFL;
+      // 0x8000 is 16b, credit to PDW
+      flex->Decode.capcode = flex->Decode.capcode << 15;
+      // add in 2068480 and first word, credit to PDW
+      // NOTE per PDW: this is not number given (2067456) in the patent for FLEX
+      flex->Decode.capcode = flex->Decode.capcode + 2068480L + aiw;
     }
 
           if ((flex->Decode.capcode >= 2029568) && (flex->Decode.capcode <= 2029583)) {

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -563,6 +563,11 @@ unsigned int add_ch(unsigned char ch, unsigned char* buf, unsigned int idx) {
         buf[idx] = ch;
         return 1;
     }
+    // if you want all non-printables, show as hex, but also make MAX_ALN 1024
+    /* if (idx < (MAX_ALN - 4)) {
+        sprintf(buf + idx, "\\x%02x", ch);
+        return 4;
+    }*/
     return 0;
 }
 
@@ -873,6 +878,7 @@ static void decode_phase(struct Flex * flex, char PhaseNo) {
       // the header is within the next VW
       hdr = j + 1;
       if (len >= 1) {
+        // per PDW
         len--;
       }
     } else {  // if short address
@@ -880,6 +886,7 @@ static void decode_phase(struct Flex * flex, char PhaseNo) {
       hdr = mw1;
       mw1++;
       if (!flex_groupmessage && len >= 1) {
+        // not in spec, possible decode issue, but this fixed repeatedly observed len issues
         len--;
       }
     }

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -571,16 +571,16 @@ static void parse_alphanumeric(struct Flex * flex, unsigned int * phaseptr, char
         if (flex==NULL) return;
         verbprintf(3, "FLEX: Parse Alpha Numeric\n");
 
+        verbprintf(1, "FLEX: %i/%i/%c %02i.%03i %10" PRId64 " %c%c|%1d|%3d\n", flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode, (flex->Decode.long_address ? 'L' : 'S'), (flex_groupmessage ? 'G' : 'S'), frag, len);
+
         time_t now=time(NULL);
         struct tm * gmt=gmtime(&now);
-        unsigned char message[MAX_ALN];
         char frag_flag = '?';
-        
-
         if (cont == 0 && frag == 3) frag_flag = 'K'; // complete, ready to send
         if (cont == 0 && frag != 3) frag_flag = 'C'; // incomplete until appended to 1 or more 'F's
         if (cont == 1             ) frag_flag = 'F'; // incomplete until a 'C' fragment is appended
 
+        unsigned char message[MAX_ALN];
         memset(message, '\0', MAX_ALN);
         int  currentChar = 0;
         // (mw + i) < PHASE_WORDS (aka mw+len<=PW) enforced within decode_phase
@@ -624,6 +624,7 @@ static void parse_alphanumeric(struct Flex * flex, unsigned int * phaseptr, char
 
 // Implemented bierviltje code from ticket: https://github.com/EliasOenal/multimon-ng/issues/123# 
         static char pt_out[4096] = { 0 };
+        // TODO make this line syntax the same as the other 'FLEX: ' lines
         int pt_offset = sprintf(pt_out, "FLEX|%04i-%02i-%02i %02i:%02i:%02i|%i/%i/%c/%c|%02i.%03i|%10" PRId64,
                         gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
                         flex->Sync.baud, flex->Sync.levels, frag_flag, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
@@ -805,7 +806,7 @@ static void decode_phase(struct Flex * flex, char PhaseNo) {
       return;
   }
   // long addresses use double AW and VW, so there are anywhere between ceil(v-a/2) to v-a pages in this frame
-  verbprintf(3, "FLEX: BlockInfoWord: (Phase %c) BIW:%08X AW:%02i-%02i (up to %i pages)\n", PhaseNo, biw, aoffset, voffset, voffset-aoffset);
+  verbprintf(3, "FLEX: BlockInfoWord: (Phase %c) BIW:%08X AW:%02u VW:%02u (up to %u pages)\n", PhaseNo, biw, aoffset, voffset, voffset-aoffset);
 
   int flex_groupmessage = 0;
   int flex_groupbit = 0;
@@ -888,7 +889,7 @@ static void decode_phase(struct Flex * flex, char PhaseNo) {
     int frag = (int) (phaseptr[hdr] >> 11) & 0x3L;
     // which spec documents a cont flag? it is used to derive the K/F/C frag_flag
     int cont = (int) (phaseptr[hdr] >> 10) & 0x1L;;
-    verbprintf(3, "FLEX: VIW: type:%d mw1:%u len:%u frag:%i\n", flex->Decode.type, mw1, len, frag);
+    verbprintf(3, "FLEX: VIW %u: type:%d mw1:%u len:%u frag:%i\n", j, flex->Decode.type, mw1, len, frag);
 
     if (flex->Decode.type == FLEX_PAGETYPE_SHORT_INSTRUCTION)
                 {

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -118,6 +118,7 @@
 #define IDLE_THRESHOLD       0             // Number of idle codewords allowed in data section
 #define CAPCODES_INDEX       0
 #define DEMOD_TIMEOUT        100           // Maximum number of periods with no zero crossings before we decide that the system is not longer within a Timing lock.
+#define GROUP_BITS           17            // Centralized maximum of group msg cache
 #define PHASE_WORDS          88            // per spec, there are 88 4B words per frame
 // there are 3 chars per message word (mw)
 // there are at most 88 words per frame's phase buffer of a page
@@ -162,9 +163,9 @@ struct Flex_Demodulator {
 };
 
 struct Flex_GroupHandler {
-  int64_t                     GroupCodes[17][1000];
-  int                     GroupCycle[17];
-  int             GroupFrame[17];
+  int64_t                     GroupCodes[GROUP_BITS][1000];
+  int                         GroupCycle[GROUP_BITS];
+  int                         GroupFrame[GROUP_BITS];
 };
 
 struct Flex_Modulation {
@@ -442,8 +443,7 @@ static int decode_fiw(struct Flex * flex) {
         timeseconds/60,
         timeseconds%60);
     // Lets check the FrameNo against the expected group message frames, if we have 'Missed a group message' tell the user and clear the Cap Codes
-                for(int g = 0; g < 17 ;g++)
-                {
+    for(int g = 0; g < GROUP_BITS ;g++) {
       // Do we have a group message pending for this groupbit?
       if(flex->GroupHandler.GroupFrame[g] >= 0)
       {
@@ -1342,7 +1342,7 @@ struct Flex * Flex_New(unsigned int SampleFrequency) {
       flex=NULL;
     }
 
-    for(int g = 0; g < 17; g++)
+    for(int g = 0; g < GROUP_BITS; g++)
     {
       flex->GroupHandler.GroupFrame[g] = -1;
           flex->GroupHandler.GroupCycle[g] = -1;

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -933,6 +933,11 @@ static void decode_phase(struct Flex * flex, char PhaseNo) {
       parse_tone_only(flex, phaseptr, PhaseNo, j); // parse_tone_only(flex, PhaseNo);
     else
       parse_unknown(flex, phaseptr, PhaseNo, mw1, len);
+
+    // long addresses eat 2 aw and 2 vw, so skip the next aw-vw pair
+    if (flex->Decode.long_address) {
+      i++;
+    }
   }
 }
 

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -629,10 +629,9 @@ static void parse_alphanumeric(struct Flex * flex, unsigned int * phaseptr, char
 
 // Implemented bierviltje code from ticket: https://github.com/EliasOenal/multimon-ng/issues/123# 
         static char pt_out[4096] = { 0 };
-        // TODO make this line syntax the same as the other 'FLEX: ' lines
-        int pt_offset = sprintf(pt_out, "FLEX|%04i-%02i-%02i %02i:%02i:%02i|%i/%i/%c/%c|%02i.%03i|%10" PRId64,
+        int pt_offset = sprintf(pt_out, "FLEX|%04i-%02i-%02i %02i:%02i:%02i|%i/%i/%c/%c|%02i.%03i|%010" PRId64,
                         gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
-                        flex->Sync.baud, flex->Sync.levels, frag_flag, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
+                        flex->Sync.baud, flex->Sync.levels, PhaseNo, frag_flag, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
 
         if(flex_groupmessage == 1) {
                 int endpoint = flex->GroupHandler.GroupCodes[flex_groupbit][CAPCODES_INDEX];
@@ -664,7 +663,7 @@ static void parse_numeric(struct Flex * flex, unsigned int * phaseptr, char Phas
 
   time_t now=time(NULL);
   struct tm * gmt=gmtime(&now);
-  verbprintf(0,  "FLEX: %04i-%02i-%02i %02i:%02i:%02i %i/%i/%c %02i.%03i [%010" PRId64 "] NUM ", gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
+  verbprintf(0,  "FLEX|%04i-%02i-%02i %02i:%02i:%02i|%i/%i/%c  |%02i.%03i|%010" PRId64 "|NUM|", gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
       flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
 
   // Get first dataword from message field or from second
@@ -723,7 +722,7 @@ static void parse_tone_only(struct Flex * flex, unsigned int * phaseptr, char Ph
   
   time_t now=time(NULL);
   struct tm * gmt=gmtime(&now);
-  verbprintf(0,  "FLEX: %04i-%02i-%02i %02i:%02i:%02i %i/%i/%c %02i.%03i [%010" PRId64 "] TON ", gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec, flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
+  verbprintf(0,  "FLEX|%04i-%02i-%02i %02i:%02i:%02i|%i/%i/%c  |%02i.%03i|%010" PRId64 "|TON|", gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec, flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
 
   // message type
   // 1=tone-only, 0=short numeric
@@ -754,7 +753,7 @@ static void parse_unknown(struct Flex * flex, unsigned int * phaseptr, char Phas
   if (flex==NULL) return;
   time_t now=time(NULL);
   struct tm * gmt=gmtime(&now);
-  verbprintf(0,  "FLEX: %04i-%02i-%02i %02i:%02i:%02i %i/%i/%c %02i.%03i [%010" PRId64 "] UNK", gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
+  verbprintf(0,  "FLEX|%04i-%02i-%02i %02i:%02i:%02i|%i/%i/%c  |%02i.%03i|%010" PRId64 "|UNK|", gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
       flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
 
   for (unsigned int i = 0; i < len; i++) {

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -614,12 +614,10 @@ static void parse_alphanumeric(struct Flex * flex, unsigned int * phaseptr, char
                 flex->GroupHandler.GroupFrame[flex_groupbit] = -1;
                 flex->GroupHandler.GroupCycle[flex_groupbit] = -1;
         } 
-        // TODO option to filter non-printables
-        // TODO option to convert '\n' and '\r' to "\\n" and "\\r"
-        // TODO don't print if empty
-        // TODO sanitize % or you will have uncontrolled format string vuln
-        pt_offset += sprintf(pt_out + pt_offset, "|ALN|%s\n", message);
-        verbprintf(0, pt_out);
+        if (message[0] != '\0') {
+            pt_offset += sprintf(pt_out + pt_offset, "|ALN|%s\n", message);
+            verbprintf(0, pt_out);
+        }
 }
 
 static void parse_numeric(struct Flex * flex, unsigned int * phaseptr, char PhaseNo, int j) {
@@ -833,7 +831,6 @@ static void decode_phase(struct Flex * flex, char PhaseNo) {
       verbprintf(3, "FLEX: Don't process group messages if a long address\n");
       return;
     }
-
 
     /*********************
      * Parse VW

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -736,21 +736,6 @@ static void parse_unknown(struct Flex * flex, unsigned int * phaseptr, char Phas
 }
 
 
-//static void parse_capcode(struct Flex * flex, uint32_t aw1, uint32_t aw2) {
-static void parse_capcode(struct Flex * flex, uint32_t aw1) {
-  if (flex==NULL) return;
-
-  flex->Decode.long_address = (aw1 < 0x8001L) ||
-    (aw1 > 0x1E0000L) ||
-    (aw1 > 0x1E7FFEL);
-
-  ///if (flex->Decode.long_address)
-  //  flex->Decode.capcode = (int64_t)aw1+((int64_t)(aw2^0x001FFFFFul)<<15)+0x1F9000ull;  // Don't ask
-  //else
-  flex->Decode.capcode = aw1-0x8000;
-}
-
-
 static void decode_phase(struct Flex * flex, char PhaseNo) {
   if (flex==NULL) return;
 
@@ -813,9 +798,15 @@ static void decode_phase(struct Flex * flex, char PhaseNo) {
       verbprintf(3, "FLEX: Idle codewords, invalid address\n");
       continue;
     }
+    /*********************
+     * Parse AW
+     */
+    uint32_t aiw = phaseptr[i];
+    flex->Decode.long_address = (aiw < 0x8001L) ||
+      (aiw > 0x1E0000L && aiw < 0x1F0001L) ||
+      (aiw > 0x1F7FFEL);
+    flex->Decode.capcode = aiw - 0x8000L;
 
-    parse_capcode(flex, phaseptr[i]);
-    // parse_capcode(flex, phaseptr[i], phaseptr[i+1]); // Older version maybe still needed so I'm not removing it (yet)
     if (flex->Decode.long_address)
     {
       verbprintf(4, "FLEX: Found 'Long Address' bit, ignoring as I think this is handled incorrectly at the moment issue#79\n");

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -948,7 +948,6 @@ static void decode_phase(struct Flex * flex, char PhaseNo) {
 
     // Check if this is an alpha message
     if (is_alphanumeric_page(flex))
-      mw1++;  // does not account for long address/group/frag/etc
       parse_alphanumeric(flex, phaseptr, PhaseNo, mw1, len, frag, cont, flex_groupmessage, flex_groupbit);
     else if (is_numeric_page(flex))
       parse_numeric(flex, phaseptr, PhaseNo, j);

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -22,6 +22,11 @@
  *      Boston, MA 02110-1301, USA.
  */
 /*
+ *  Modification (to this file) made by Ryan Farley (rfarley3@github)
+ *   - Issue #139 !160 handle edge cases for start and end offsets (long vs short, single vs group)
+ *   - Resolve type ambiguity to improve stability after Raspberry Pi compile
+ *   - Compare algorithms to other open source libraries to reconcile group bit, frag bit, and capcode decode
+ *   - Refactor message printing to single line, only printables, encoded % fmtstr directives
  *  Version 0.9.3v (28 Jan 2020)
  *  Modification made by bierviltje and implemented by Bruce Quinton (Zanoroy@gmail.com)
  *   - Issue #123 created by bierviltje (https://github.com/bierviltje) - Feature request: FLEX: put group messages in an array/list

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -788,6 +788,7 @@ static void decode_phase(struct Flex * flex, char PhaseNo) {
   verbprintf(3, "FLEX: BlockInfoWord: (Phase %c) BIW:%08X AW:%02i-%02i (%i pages)\n", PhaseNo, biw, aoffset, voffset, voffset-aoffset);
 
   int flex_groupmessage = 0;
+  int flex_groupbit = 0;
 
   // Iterate through pages and dispatch to appropriate handler
   for (i = aoffset; i < voffset; i++) {
@@ -816,8 +817,12 @@ static void decode_phase(struct Flex * flex, char PhaseNo) {
       flex->Decode.capcode = flex->Decode.capcode + 2068480L + aiw;
     }
 
+    flex_groupmessage = 0;
+    flex_groupbit = 0;
           if ((flex->Decode.capcode >= 2029568) && (flex->Decode.capcode <= 2029583)) {
              flex_groupmessage = 1;
+             flex_groupbit = flex->Decode.capcode - 2029568;
+             if(flex_groupbit < 0) continue;
           }
 
     if (flex->Decode.capcode > 4297068542ll || flex->Decode.capcode < 0) {    // Invalid address (by spec, maximum address)

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -565,7 +565,7 @@ unsigned int add_ch(unsigned char ch, unsigned char* buf, unsigned int idx) {
 }
 
 
-static void parse_alphanumeric(struct Flex * flex, unsigned int * phaseptr, char PhaseNo, unsigned int mw1, unsigned int len, int cont, int frag, int flex_groupmessage, int groupbit) {
+static void parse_alphanumeric(struct Flex * flex, unsigned int * phaseptr, char PhaseNo, unsigned int mw1, unsigned int len, int cont, int frag, int flex_groupmessage, int flex_groupbit) {
         if (flex==NULL) return;
         verbprintf(3, "FLEX: Parse Alpha Numeric\n");
 
@@ -584,7 +584,7 @@ static void parse_alphanumeric(struct Flex * flex, unsigned int * phaseptr, char
         int  currentChar = 0;
         // (mw + i) < PHASE_WORDS (aka mw+len<=PW) enforced within decode_phase
         for (i = 0; i < len; i++) {
-            unsigned int dw =  phaseptr[mw + i];
+            unsigned int dw =  phaseptr[mw1 + i];
             if (i > 0 || frag != 0x03) {
                 currentChar += add_ch(dw & 0x7Fl, message, currentChar);
             }
@@ -877,7 +877,7 @@ static void decode_phase(struct Flex * flex, char PhaseNo) {
       // the header is within the message
       hdr = mw1;
       mw1++;
-      if (!flex->Decode.is_groupmessage && len >= 1) {
+      if (!flex_groupmessage && len >= 1) {
         len--;
       }
     }

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -102,6 +102,8 @@
 #include <time.h>
 #include <stdlib.h>
 #include <stdio.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 
 /* ---------------------------------------------------------------------- */
 
@@ -491,7 +493,7 @@ static int decode_fiw(struct Flex * flex) {
           {
             if(REPORT_GROUP_CODES == 0)
             {
-              verbprintf(3,"FLEX: Group messages seem to have been missed; Groupbit: %i; Clearing data; Capcode: [%09lld]\n", g, flex->GroupHandler.GroupCodes[g][capIndex]);
+              verbprintf(3,"FLEX: Group messages seem to have been missed; Groupbit: %i; Clearing data; Capcode: [%010" PRId64 "]\n", g, flex->GroupHandler.GroupCodes[g][capIndex]);
             }
             else
             {
@@ -499,7 +501,7 @@ static int decode_fiw(struct Flex * flex) {
               {
                 verbprintf(3,",");
               }
-              verbprintf(3,"[%09lld]", flex->GroupHandler.GroupCodes[g][capIndex]);
+              verbprintf(3,"[%010" PRId64 "]", flex->GroupHandler.GroupCodes[g][capIndex]);
             }
           }
 
@@ -623,7 +625,7 @@ static void parse_alphanumeric(struct Flex * flex, unsigned int * phaseptr, char
 
 // Implemented bierviltje code from ticket: https://github.com/EliasOenal/multimon-ng/issues/123# 
         static char pt_out[4096] = { 0 };
-        int pt_offset = sprintf(pt_out, "FLEX|%04i-%02i-%02i %02i:%02i:%02i|%i/%i/%c/%c|%02i.%03i|%09lld",
+        int pt_offset = sprintf(pt_out, "FLEX|%04i-%02i-%02i %02i:%02i:%02i|%i/%i/%c/%c|%02i.%03i|%10" PRId64,
                         gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
                         flex->Sync.baud, flex->Sync.levels, frag_flag, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
 
@@ -631,8 +633,8 @@ static void parse_alphanumeric(struct Flex * flex, unsigned int * phaseptr, char
                 int endpoint = flex->GroupHandler.GroupCodes[flex_groupbit][CAPCODES_INDEX];
                 for(int g = 1; g <= endpoint;g++)
                 {
-                        verbprintf(1, "FLEX Group message output: Groupbit: %i Total Capcodes; %i; index %i; Capcode: [%09lld]\n", flex_groupbit, endpoint, g, flex->GroupHandler.GroupCodes[flex_groupbit][g]);
-                        pt_offset += sprintf(pt_out + pt_offset, " %09lld", flex->GroupHandler.GroupCodes[flex_groupbit][g]);
+                        verbprintf(1, "FLEX Group message output: Groupbit: %i Total Capcodes; %i; index %i; Capcode: [%010" PRId64 "]\n", flex_groupbit, endpoint, g, flex->GroupHandler.GroupCodes[flex_groupbit][g]);
+                        pt_offset += sprintf(pt_out + pt_offset, " %010" PRId64, flex->GroupHandler.GroupCodes[flex_groupbit][g]);
                 }
 
                 // reset the value
@@ -657,7 +659,7 @@ static void parse_numeric(struct Flex * flex, unsigned int * phaseptr, char Phas
 
   time_t now=time(NULL);
   struct tm * gmt=gmtime(&now);
-  verbprintf(0,  "FLEX: %04i-%02i-%02i %02i:%02i:%02i %i/%i/%c %02i.%03i [%09lld] NUM ", gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
+  verbprintf(0,  "FLEX: %04i-%02i-%02i %02i:%02i:%02i %i/%i/%c %02i.%03i [%010] NUM ", gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
       flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
 
   // Get first dataword from message field or from second
@@ -716,7 +718,7 @@ static void parse_tone_only(struct Flex * flex, unsigned int * phaseptr, char Ph
   
   time_t now=time(NULL);
   struct tm * gmt=gmtime(&now);
-  verbprintf(0,  "FLEX: %04i-%02i-%02i %02i:%02i:%02i %i/%i/%c %02i.%03i [%09lld] TON ", gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec, flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
+  verbprintf(0,  "FLEX: %04i-%02i-%02i %02i:%02i:%02i %i/%i/%c %02i.%03i [%010" PRId64 "] TON ", gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec, flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
 
   // message type
   // 1=tone-only, 0=short numeric
@@ -747,7 +749,7 @@ static void parse_unknown(struct Flex * flex, unsigned int * phaseptr, char Phas
   if (flex==NULL) return;
   time_t now=time(NULL);
   struct tm * gmt=gmtime(&now);
-  verbprintf(0,  "FLEX: %04i-%02i-%02i %02i:%02i:%02i %i/%i/%c %02i.%03i [%09lld] UNK", gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
+  verbprintf(0,  "FLEX: %04i-%02i-%02i %02i:%02i:%02i %i/%i/%c %02i.%03i [%010" PRId64 "] UNK", gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
       flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
 
   for (int i = 0; i < len; i++) {
@@ -902,7 +904,7 @@ static void decode_phase(struct Flex * flex, char PhaseNo) {
         ////////#############################################################################                 
                     flex->GroupHandler.GroupCodes[groupbit][CAPCODES_INDEX]++;
                     int CapcodePlacement = flex->GroupHandler.GroupCodes[groupbit][CAPCODES_INDEX];
-                    verbprintf(1, "FLEX: Found Short Instruction, Group bit: %i capcodes in group so far %i, adding Capcode: [%09lld]\n", groupbit, CapcodePlacement, flex->Decode.capcode);
+                    verbprintf(1, "FLEX: Found Short Instruction, Group bit: %i capcodes in group so far %i, adding Capcode: [%010" PRId64 "]\n", groupbit, CapcodePlacement, flex->Decode.capcode);
 
                     flex->GroupHandler.GroupCodes[groupbit][CapcodePlacement] = flex->Decode.capcode;
                     flex->GroupHandler.GroupFrame[groupbit] = iAssignedFrame;

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -567,7 +567,7 @@ unsigned int add_ch(unsigned char ch, unsigned char* buf, unsigned int idx) {
 }
 
 
-static void parse_alphanumeric(struct Flex * flex, unsigned int * phaseptr, char PhaseNo, unsigned int mw1, unsigned int len, int cont, int frag, int flex_groupmessage, int flex_groupbit) {
+static void parse_alphanumeric(struct Flex * flex, unsigned int * phaseptr, char PhaseNo, unsigned int mw1, unsigned int len, int frag, int cont, int flex_groupmessage, int flex_groupbit) {
         if (flex==NULL) return;
         verbprintf(3, "FLEX: Parse Alpha Numeric %u %u\n", mw1, len);
 

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -659,7 +659,7 @@ static void parse_numeric(struct Flex * flex, unsigned int * phaseptr, char Phas
 
   time_t now=time(NULL);
   struct tm * gmt=gmtime(&now);
-  verbprintf(0,  "FLEX: %04i-%02i-%02i %02i:%02i:%02i %i/%i/%c %02i.%03i [%010] NUM ", gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
+  verbprintf(0,  "FLEX: %04i-%02i-%02i %02i:%02i:%02i %i/%i/%c %02i.%03i [%010" PRId64 "] NUM ", gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
       flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
 
   // Get first dataword from message field or from second
@@ -842,10 +842,10 @@ static void decode_phase(struct Flex * flex, char PhaseNo) {
     }
     if (flex->Decode.capcode > 4297068542LL || flex->Decode.capcode < 0) {
       // Invalid address (by spec, maximum address)
-      verbprintf(3, "FLEX: Invalid address, capcode out of range %lld\n", flex->Decode.capcode);
+      verbprintf(3, "FLEX: Invalid address, capcode out of range %" PRId64 "\n", flex->Decode.capcode);
       continue;
     }
-    verbprintf(3, "FLEX: CAPCODE:%016lx %ld\n", flex->Decode.capcode, flex->Decode.capcode);
+    verbprintf(3, "FLEX: CAPCODE:%016" PRIx64 " %" PRId64 "\n", flex->Decode.capcode, flex->Decode.capcode);
 
     flex_groupmessage = 0;
     flex_groupbit = 0;


### PR DESCRIPTION
Fixes #139 adds edges cases for start and end offsets to avoid missing start characters in FLEX messages.

Also include some changes that:
* remove compiler warnings/type ambiguity when on Raspberry Pi architecture
* refactors mw1 and len calculations into single place
* centralize hardcoded sizes and offsets
* handle long vs short address and single vs group decoding, particular as it pertains to:
    * changing the start and end offset of message content
    * decoding the capcode
    * decode the frag bit
* refactors the message printing to encode printable whitespace modifiers so messages are printing on a single line, avoid empty messages, filter non-printables, convert % into literal (%%).