### PR TITLE
Pass --ignore-length to SoX to support piped WAV data

### DIFF
--- a/unixinput.c
+++ b/unixinput.c
@@ -499,6 +499,7 @@ static void input_file(unsigned int sample_rate, unsigned int overlap,
                 perror("dup2");
             close(pipedes[1]); /* close writing pipe end */
             execlp("sox", "sox", repeatable_sox?"-R":"-V2", mute_sox?"-V1":"-V2",
+                   "--ignore-length",
                    "-t", type, fname,
                    "-t", "raw", "-esigned-integer", "-b16", "-r", srate, "-", "remix", "1",
                    NULL);


### PR DESCRIPTION
When multimon-ng reads a WAV file it uses SoX to convert it to raw
samples. If that data is streamed via a pipe then the WAV header will
not contain the right length, so SoX will terminate early.

This adds --ignore-length to SoX's argument list, which will make it
read until the end of the input file.

Closes: #194 