### PR TITLE
Bug / security fix: printf format string uses received data

### DIFF
--- a/demod_flex.c
+++ b/demod_flex.c
@@ -611,7 +611,7 @@ static void parse_alphanumeric(struct Flex * flex, unsigned int * phaseptr, char
                 flex->GroupHandler.GroupCycle[groupbit] = -1;
         } 
         pt_offset += sprintf(pt_out + pt_offset, "|ALN|%s\n", message);
-        verbprintf(0, pt_out);
+        verbprintf(0, "%s", pt_out);
 }
 
 static void parse_numeric(struct Flex * flex, unsigned int * phaseptr, char PhaseNo, int j) {


### PR DESCRIPTION
Multimon from Debian crashed when decoding pager flex data, with an error message about %n printf vulnerabilities.  I found that a verbprintf call in demod_flex.c had only two params, so the pager payload was being sent as a format string.

I confirmed that a pager text had contained the characters "%n", which caused the crash. 

The fix is to just add %s, which treats the data as a string, rather than a format.  After the fix, I replayed the data, and no crash happened.

https://cs155.stanford.edu/papers/formatstring-1.2.pdf
