### PR TITLE
Fixing POCSAG decoders not working when fed small data over pipes, etc.

### DIFF
--- a/demod_afsk12.c
+++ b/demod_afsk12.c
@@ -1,7 +1,7 @@
 /*
  *      demod_afsk12.c -- 1200 baud AFSK demodulator
  *
- *      Copyright (C) 1996  
+ *      Copyright (C) 1996
  *          Thomas Sailer (sailer@ife.ee.ethz.ch, hb9jnx@hb9w.che.eu)
  *
  *      This program is free software; you can redistribute it and/or modify

--- a/demod_poc12.c
+++ b/demod_poc12.c
@@ -54,16 +54,15 @@ static void poc12_init(struct demod_state *s)
 static void poc12_demod(struct demod_state *s, buffer_t buffer, int length)
 {
 	if (s->l1.poc12.subsamp) {
-		int numfill = SUBSAMP - s->l1.poc12.subsamp;
-		if (length < numfill) {
-			s->l1.poc12.subsamp += length;
+		if (length <= (int)s->l1.poc12.subsamp) {
+			s->l1.poc12.subsamp -= length;
 			return;
 		}
-		buffer.fbuffer += numfill;
-		length -= numfill;
+		buffer.fbuffer += s->l1.poc12.subsamp;
+		length -= s->l1.poc12.subsamp;
 		s->l1.poc12.subsamp = 0;
 	}
-	for (; length >= SUBSAMP; length -= SUBSAMP, buffer.fbuffer += SUBSAMP) {
+	for (; length > 0; length -= SUBSAMP, buffer.fbuffer += SUBSAMP) {
 		s->l1.poc12.dcd_shreg <<= 1;
 		s->l1.poc12.dcd_shreg |= ((*buffer.fbuffer) > 0);
 		verbprintf(10, "%c", '0'+(s->l1.poc12.dcd_shreg & 1));
@@ -82,7 +81,7 @@ static void poc12_demod(struct demod_state *s, buffer_t buffer, int length)
 			pocsag_rxbit(s, s->l1.poc12.dcd_shreg & 1);
 		}
 	}
-	s->l1.poc12.subsamp = length;
+	s->l1.poc12.subsamp = -length;
 }
 
 static void poc12_deinit(struct demod_state *s)

--- a/demod_poc12.c
+++ b/demod_poc12.c
@@ -1,8 +1,10 @@
 /*
  *      demod_poc12.c -- 1200 baud POCSAG demodulator
  *
- *      Copyright (C) 1996  
+ *      Copyright (C) 1996
  *          Thomas Sailer (sailer@ife.ee.ethz.ch, hb9jnx@hb9w.che.eu)
+ *      Copyright (C) 2024
+ *          Marat Fayzullin (luarvique@gmail.com)
  *
  *      POCSAG (Post Office Code Standard Advisory Group)
  *      Radio Paging Decoder

--- a/demod_poc5.c
+++ b/demod_poc5.c
@@ -1,8 +1,10 @@
 /*
  *      demod_poc5.c -- 512 baud POCSAG demodulator
  *
- *      Copyright (C) 1996  
+ *      Copyright (C) 1996
  *          Thomas Sailer (sailer@ife.ee.ethz.ch, hb9jnx@hb9w.che.eu)
+ *      Copyright (C) 2024
+ *          Marat Fayzullin (luarvique@gmail.com)
  *
  *      POCSAG (Post Office Code Standard Advisory Group)
  *      Radio Paging Decoder


### PR DESCRIPTION
Fixed POCSAG512 and POCSAG1200 decoders not working when fed small amounts of data (e.g. pipes, etc). This should fix issues #213, #197, #91, #70.

The same problem may be present in some other decoders. I have not checked. Please, do.
