### PR TITLE
Timestamp UTC ISO-8601 mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ else( PULSE_AUDIO_SUPPORT )
 endif( PULSE_AUDIO_SUPPORT )
 
 if( NOT MSVC )
-	add_definitions( "-std=gnu99" )
+	add_definitions( "-std=gnu11" )
 endif( NOT MSVC )
 add_definitions( "-DMAX_VERBOSE_LEVEL=3" "-DCHARSET_UTF8" )
 


### PR DESCRIPTION
Adds an `--iso-8601` argument so that timestamps are UTC based and include microseconds. This is especially useful when:

1. passing data between systems
2. Timestamps aren't affected by Daylight Saving Time changes
3. A lot can happen in a second and makes it easier to filter/correlate log entries with other components

Output example:
```
2024-09-13T21:57:39.154618: FLEX|2024-09-13 21:57:39|1600/2/K/A|03.011|002029575 000120111 000120999|ALN|A2 13111 Tweede Oosterparkstraat 1092 Amsterdam 82536
```