### PR TITLE
FLEX: Suppress timestamp by passing `--flex-no-ts`

### DIFF
--- a/demod_flex.c
+++ b/demod_flex.c
@@ -667,9 +667,19 @@ static void parse_numeric(struct Flex * flex, unsigned int * phaseptr, char Phas
 
   time_t now=time(NULL);
   struct tm * gmt=gmtime(&now);
-  verbprintf(0,  "FLEX: %04i-%02i-%02i %02i:%02i:%02i %i/%i/%c %02i.%03i [%09lld] NUM ", gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
-      flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
 
+  if(flex_disable_timestamp)
+  {
+    verbprintf(0,  "FLEX|%i/%i/%c|%02i.%03i|[%09lld]|NUM ",
+        flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
+  }
+  else
+  {
+    verbprintf(0,  "FLEX: %04i-%02i-%02i %02i:%02i:%02i %i/%i/%c %02i.%03i [%09lld] NUM ",
+        gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
+        flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
+  }
+  
   // Get first dataword from message field or from second
   // vector word if long address
   int dw;
@@ -726,7 +736,18 @@ static void parse_tone_only(struct Flex * flex, unsigned int * phaseptr, char Ph
   
   time_t now=time(NULL);
   struct tm * gmt=gmtime(&now);
-  verbprintf(0,  "FLEX: %04i-%02i-%02i %02i:%02i:%02i %i/%i/%c %02i.%03i [%09lld] TON ", gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec, flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
+
+  if(flex_disable_timestamp)
+  {
+    verbprintf(0,  "FLEX|%i/%i/%c|%02i.%03i|[%09lld]|TON ",
+      flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
+  }
+  else
+  {
+    verbprintf(0,  "FLEX: %04i-%02i-%02i %02i:%02i:%02i %i/%i/%c %02i.%03i [%09lld] TON ",
+      gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
+      flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
+  }
 
   // message type
   // 1=tone-only, 0=short numeric
@@ -757,9 +778,19 @@ static void parse_unknown(struct Flex * flex, unsigned int * phaseptr, char Phas
   if (flex==NULL) return;
   time_t now=time(NULL);
   struct tm * gmt=gmtime(&now);
-  verbprintf(0,  "FLEX: %04i-%02i-%02i %02i:%02i:%02i %i/%i/%c %02i.%03i [%09lld] UNK", gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
-      flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
 
+  if(flex_disable_timestamp)
+  {
+    verbprintf(0,  "FLEX|%i/%i/%c|%02i.%03i|[%09lld]|UNK",
+        flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
+  }
+  else
+  {
+    verbprintf(0,  "FLEX: %04i-%02i-%02i %02i:%02i:%02i %i/%i/%c %02i.%03i [%09lld] UNK",
+        gmt->tm_year+1900, gmt->tm_mon+1, gmt->tm_mday, gmt->tm_hour, gmt->tm_min, gmt->tm_sec,
+        flex->Sync.baud, flex->Sync.levels, PhaseNo, flex->FIW.cycleno, flex->FIW.frameno, flex->Decode.capcode);
+  }
+  
   int i;
   for (i = mw1; i <= mw2; i++) {
     verbprintf(0, " %08x", phaseptr[i]);

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -122,7 +122,7 @@
 #define CAPCODES_INDEX       0
 #define DEMOD_TIMEOUT        100           // Maximum number of periods with no zero crossings before we decide that the system is not longer within a Timing lock.
 
-int flex_disable_timestamp;
+int flex_disable_timestamp = 0;
 
 
 enum Flex_PageTypeEnum {

--- a/unixinput.c
+++ b/unixinput.c
@@ -110,6 +110,8 @@ extern int cw_threshold;
 extern bool cw_disable_auto_threshold;
 extern bool cw_disable_auto_timing;
 
+extern int flex_disable_timestamp;
+
 void quit(void);
 
 /* ---------------------------------------------------------------------- */
@@ -569,35 +571,37 @@ static const char usage_str[] = "\n"
         "Usage: %s [file] [file] [file] ...\n"
         "  If no [file] is given, input will be read from your default sound\n"
         "  hardware. A filename of \"-\" denotes standard input.\n"
-        "  -t <type>  : Input file type (any other type than raw requires sox)\n"
-        "  -a <demod> : Add demodulator\n"
-        "  -s <demod> : Subtract demodulator\n"
-        "  -c         : Remove all demodulators (must be added with -a <demod>)\n"
-        "  -q         : Quiet\n"
-        "  -v <level> : Level of verbosity (e.g. '-v 3')\n"
-        "               For POCSAG and MORSE_CW '-v1' prints decoding statistics.\n"
-        "  -h         : This help\n"
-        "  -A         : APRS mode (TNC2 text output)\n"
-        "  -m         : Mute SoX warnings\n"
-        "  -r         : Call SoX in repeatable mode (e.g. fixed random seed for dithering)\n"
-        "  -n         : Don't flush stdout, increases performance.\n"
-        "  -j         : FMS: Just output hex data and CRC, no parsing.\n"
-        "  -e         : POCSAG: Hide empty messages.\n"
-        "  -u         : POCSAG: Heuristically prune unlikely decodes.\n"
-        "  -i         : POCSAG: Inverts the input samples. Try this if decoding fails.\n"
-        "  -p         : POCSAG: Show partially received messages.\n"
-        "  -f <mode>  : POCSAG: Overrides standards and forces decoding of data as <mode>\n"
-        "                       (<mode> can be 'numeric', 'alpha', 'skyper' or 'auto')\n"
-        "  -b <level> : POCSAG: BCH bit error correction level. Set 0 to disable, default is 2.\n"
-        "                       Lower levels increase performance and lower false positives.\n"
-        "  -C <cs>    : POCSAG: Set Charset.\n"
-        "  -o         : CW: Set threshold for dit detection (default: 500)\n"
-        "  -d         : CW: Dit length in ms (default: 50)\n"
-        "  -g         : CW: Gap length in ms (default: 50)\n"
-        "  -x         : CW: Disable auto threshold detection\n"
-        "  -y         : CW: Disable auto timing detection\n"
-        "  --timestamp: Add a time stamp in front of every printed line\n"
-        "  --label    : Add a label to the front of every printed line\n"
+        "  -t <type>    : Input file type (any other type than raw requires sox)\n"
+        "  -a <demod>   : Add demodulator\n"
+        "  -s <demod>   : Subtract demodulator\n"
+        "  -c           : Remove all demodulators (must be added with -a <demod>)\n"
+        "  -q           : Quiet\n"
+        "  -v <level>   : Level of verbosity (e.g. '-v 3')\n"
+        "                 For POCSAG and MORSE_CW '-v1' prints decoding statistics.\n"
+        "  -h           : This help\n"
+        "  -A           : APRS mode (TNC2 text output)\n"
+        "  -m           : Mute SoX warnings\n"
+        "  -r           : Call SoX in repeatable mode (e.g. fixed random seed for dithering)\n"
+        "  -n           : Don't flush stdout, increases performance.\n"
+        "  -j           : FMS: Just output hex data and CRC, no parsing.\n"
+        "  -e           : POCSAG: Hide empty messages.\n"
+        "  -u           : POCSAG: Heuristically prune unlikely decodes.\n"
+        "  -i           : POCSAG: Inverts the input samples. Try this if decoding fails.\n"
+        "  -p           : POCSAG: Show partially received messages.\n"
+        "  -f <mode>    : POCSAG: Overrides standards and forces decoding of data as <mode>\n"
+        "                         (<mode> can be 'numeric', 'alpha', 'skyper' or 'auto')\n"
+        "  -b <level>   : POCSAG: BCH bit error correction level. Set 0 to disable, default is 2.\n"
+        "                         Lower levels increase performance and lower false positives.\n"
+        "  -C <cs>      : POCSAG: Set Charset.\n"
+        "  -o           : CW: Set threshold for dit detection (default: 500)\n"
+        "  -d           : CW: Dit length in ms (default: 50)\n"
+        "  -g           : CW: Gap length in ms (default: 50)\n"
+        "  -x           : CW: Disable auto threshold detection\n"
+        "  -y           : CW: Disable auto timing detection\n"
+        "  --timestamp  : Add a time stamp in front of every printed line\n"
+        "  --label      : Add a label to the front of every printed line\n"
+        "  --flex-no-ts : FLEX: Do not add a timestamp to the FLEX demodulator output\n"
+        "\n"
         "   Raw input requires one channel, 16 bit, signed integer (platform-native)\n"
         "   samples at the demodulator's input sampling rate, which is\n"
         "   usually 22050 Hz. Raw input is assumed and required if piped input is used.\n";
@@ -617,6 +621,7 @@ int main(int argc, char *argv[])
     static struct option long_options[] =
       {
         {"timestamp", no_argument, &timestamp, 1},
+        {"flex-no-ts", no_argument, &flex_disable_timestamp, 1},
         {"label", required_argument, NULL, 'l'},
         {"charset", required_argument, NULL, 'C'},
         {0, 0, 0, 0}


### PR DESCRIPTION
Suppress timestamp by passing the argument `--flex-no-ts`

1. Many users incorrectly assume the timestamp originates from the FLEX message but its the system time. The value is useless when for example passing a recording.
2. Suppressing the timestamp makes it easier to compare output of this and future versions based on the same input file.



Default:

```
FLEX|2024-09-12 16:37:13|1600/2/K/A|03.011|002029575 000120111 000120999|ALN|A2 13111 Tweede Oosterparkstraat 1092 Amsterdam 82536
```

With  `--flex-no-ts`
```
FLEX|1600/2/K/A|03.011|002029575 000120111 000120999|ALN|A2 13111 Tweede Oosterparkstraat 1092 Amsterdam 82536
```

With  `--flex-no-ts --timestamp`
```
2024-09-12 18:40:16: FLEX|1600/2/K/A|03.011|002029575 000120111 000120999|ALN|A2 13111 Tweede Oosterparkstraat 1092 Amsterdam 82536
```