### PR TITLE
FLEX: Fix edge case where no timestamp prefix was added when running with `--timestamp`

### DIFF
--- a/demod_flex.c
+++ b/demod_flex.c
@@ -652,8 +652,8 @@ static void parse_alphanumeric(struct Flex * flex, unsigned int * phaseptr, char
                 flex->GroupHandler.GroupFrame[groupbit] = -1;
                 flex->GroupHandler.GroupCycle[groupbit] = -1;
         } 
-        pt_offset += sprintf(pt_out + pt_offset, "|ALN|%s\n", message);
-        verbprintf(0, "%s", pt_out);
+        pt_offset += sprintf(pt_out + pt_offset, "|ALN|%s", message);
+        verbprintf(0, "%s\n", pt_out);
 }
 
 static void parse_numeric(struct Flex * flex, unsigned int * phaseptr, char PhaseNo, int j) {


### PR DESCRIPTION
When using `--timestamp` the prefix was only added to the first FLEX outputted message.

Fix where \n was not passed to `verbprintf` thus not detected resulting in its new line detection to fail and no timestamp prefix to appear until an `verbprintf` invocation happened that did trigger the new line if branch.

Before:
```
2024-09-15T18:24:05.392795: FLEX|1600/2/K/A|06.012|002029572 001403003 001403590|ALN|P 2 BRT-02 Liftopsluiting Johan de Wittstraat Dordrecht 186531
FLEX|1600/2/K/A|06.031|002029578 001420059 001420999|ALN|A0 AMBU 17992 Bekestein 3343CB Hendrik-Ido-Ambacht HENDIA bon 130990
FLEX|1600/2/K/A|06.040|002029568 001002747 001002750 001002873 001002880 001005998 001033002|ALN|P 2 BLB-01 Bodemverontreiniging Newtonweg Venlo 233291 236121
```
After:
```
2024-09-15T18:24:05.392795: FLEX|1600/2/K/A|06.012|002029572 001403003 001403590|ALN|P 2 BRT-02 Liftopsluiting Johan de Wittstraat Dordrecht 186531
2024-09-15T18:24:40.929980: FLEX|1600/2/K/A|06.031|002029578 001420059 001420999|ALN|A0 AMBU 17992 Bekestein 3343CB Hendrik-Ido-Ambacht HENDIA bon 130990
2024-09-15T18:24:57.857187: FLEX|1600/2/K/A|06.040|002029568 001002747 001002750 001002873 001002880 001005998 001033002|ALN|P 2 BLB-01 Bodemverontreiniging Newtonweg Venlo 233291 236121
```