### PR TITLE
Fix building with CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.5 )
+cmake_minimum_required( VERSION 2.8.12...3.10 )
 
 # The "MSVC" flag isn't set until the "project" command
 # is called.  Let's just check the operating system.


### PR DESCRIPTION
This fixes:
https://bugs.debian.org/1113302
```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```