### PR TITLE
(Feat) Respect timestamp flags in json mode

### DIFF
--- a/demod_dtmf.c
+++ b/demod_dtmf.c
@@ -156,6 +156,7 @@ static void dtmf_demod(struct demod_state *s, buffer_t buffer, int length)
 					cJSON_AddStringToObject(json_output, "demod_name", "DTMF");
 					char digit[2] = {dtmf_transl[i], '\0'};
 					cJSON_AddStringToObject(json_output, "digit", digit);
+					addJsonTimestamp(json_output);
 					fprintf(stdout, "%s\n", cJSON_PrintUnformatted(json_output));
 					cJSON_Delete(json_output);
 				}

--- a/demod_eas.c
+++ b/demod_eas.c
@@ -246,6 +246,7 @@ static void eas_frame(struct demod_state *s, char data)
                       cJSON_AddStringToObject(json_output, "demod_name", s->dem_par->name);
                       cJSON_AddStringToObject(json_output, "header_begin", HEADER_BEGIN);
                       cJSON_AddStringToObject(json_output, "last_message", s->l2.eas.last_message);
+                      addJsonTimestamp(json_output);
                       fprintf(stdout, "%s\n", cJSON_PrintUnformatted(json_output));
                   }
                   i = MAX_STORE_MSG;
@@ -264,6 +265,7 @@ static void eas_frame(struct demod_state *s, char data)
          else {
              cJSON_AddStringToObject(json_output, "demod_name", s->dem_par->name);
              cJSON_AddStringToObject(json_output, "end_of_message", EOM);
+             addJsonTimestamp(json_output);
              fprintf(stdout, "%s\n", cJSON_PrintUnformatted(json_output));
          }
        }

--- a/demod_flex.c
+++ b/demod_flex.c
@@ -683,6 +683,7 @@ static void parse_alphanumeric(struct Flex * flex, unsigned int * phaseptr, char
         else {
             cJSON_AddStringToObject(json_output, "demod_name", "flex_alphanumeric");
             cJSON_AddStringToObject(json_output, "message", message);
+            addJsonTimestamp(json_output);
             fprintf(stdout, "%s\n", cJSON_PrintUnformatted(json_output));
         }
   verbprintf(1, "Delete json_output\n");
@@ -780,6 +781,7 @@ static void parse_numeric(struct Flex * flex, unsigned int * phaseptr, char Phas
   else {
     cJSON_AddStringToObject(json_output, "demod_name", "flex_numeric");
     cJSON_AddStringToObject(json_output, "message", json_temp);
+    addJsonTimestamp(json_output);
     fprintf(stdout, "%s\n", cJSON_PrintUnformatted(json_output));
     cJSON_Delete(json_output);
   }
@@ -876,6 +878,7 @@ static void parse_tone_only(struct Flex * flex, unsigned int * phaseptr, char Ph
   }
   else {
     cJSON_AddStringToObject(json_output, "demod_name", "flex_tone_only");
+    addJsonTimestamp(json_output);
     fprintf(stdout, "%s\n", cJSON_PrintUnformatted(json_output));
     cJSON_Delete(json_output);
   }
@@ -932,6 +935,7 @@ static void parse_unknown(struct Flex * flex, unsigned int * phaseptr, char Phas
   else {
     cJSON_AddStringToObject(json_output, "demod_name", "flex_unknown");
     cJSON_AddStringToObject(json_output, "message", json_temp);
+    addJsonTimestamp(json_output);
     fprintf(stdout, "%s\n", cJSON_PrintUnformatted(json_output));
     cJSON_Delete(json_output);
   }

--- a/multimon.h
+++ b/multimon.h
@@ -34,6 +34,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "cJSON.h"
 
 #ifdef _MSC_VER
 #include "msvc_support.h"
@@ -372,6 +373,7 @@ int xdisp_start(void);
 int xdisp_update(int cnum, float *f);
 
 void print_json(int argc, char **argv);
+void addJsonTimestamp(cJSON *json_output);
 
 /* ---------------------------------------------------------------------- */
 #endif /* _MULTIMON_H */

--- a/pocsag.c
+++ b/pocsag.c
@@ -563,6 +563,7 @@ static void pocsag_printmessage(struct demod_state *s, bool sync)
                 cJSON_AddStringToObject(json_output, "demod_name", s->dem_par->name);
                 cJSON_AddNumberToObject(json_output, "address", s->l2.pocsag.address);
                 cJSON_AddNumberToObject(json_output, "function", s->l2.pocsag.function);
+                addJsonTimestamp(json_output);
                 fprintf(stdout, "%s\n", cJSON_PrintUnformatted(json_output));
                 cJSON_Delete(json_output);
             }
@@ -623,6 +624,7 @@ static void pocsag_printmessage(struct demod_state *s, bool sync)
                 }
                 else {
                     cJSON_AddStringToObject(json_output, "numeric", num_string);
+                    addJsonTimestamp(json_output);
                     fprintf(stdout, "%s\n", cJSON_PrintUnformatted(json_output));
                     fflush(stdout);
                     cJSON_Delete(json_output);
@@ -661,6 +663,7 @@ static void pocsag_printmessage(struct demod_state *s, bool sync)
                 }
                 else {
                     cJSON_AddStringToObject(json_output, "alpha", alpha_string);
+                    addJsonTimestamp(json_output);
                     fprintf(stdout, "%s\n", cJSON_PrintUnformatted(json_output));
                     fflush(stdout);
                     cJSON_Delete(json_output);
@@ -695,6 +698,7 @@ static void pocsag_printmessage(struct demod_state *s, bool sync)
                 }
                 else {
                     cJSON_AddStringToObject(json_output, "skyper", skyper_string);
+                    addJsonTimestamp(json_output);
                     fprintf(stdout, "%s\n", cJSON_PrintUnformatted(json_output));
                     fflush(stdout);
                     cJSON_Delete(json_output);

--- a/unixinput.c
+++ b/unixinput.c
@@ -169,6 +169,33 @@ void _verbprintf(int verb_level, const char *fmt, ...)
 
 /* ---------------------------------------------------------------------- */
 
+void addJsonTimestamp(cJSON *json_output)
+{
+    if (json_output==NULL) return;
+    if (!timestamp) return;
+
+    char json_temp[100];
+    if(iso8601)
+    {
+        struct timespec ts;
+        timespec_get(&ts, TIME_UTC);
+        strftime(json_temp, sizeof json_temp, "%FT%T", gmtime(&ts.tv_sec)); //2024-09-13T20:35:30
+        snprintf(json_temp + strlen(json_temp), sizeof json_temp - strlen(json_temp), ".%06ld", ts.tv_nsec/1000); //2024-09-13T20:35:30.156337
+    }
+    else
+    {
+        time_t t;
+        struct tm* tm_info;
+        t = time(NULL);
+        tm_info = localtime(&t);
+        strftime(json_temp, sizeof(json_temp), "%Y-%m-%d %H:%M:%S", tm_info);
+    }
+    cJSON_AddStringToObject(json_output, "timestamp", json_temp);
+
+}
+
+/* ---------------------------------------------------------------------- */
+
 void process_buffer(float *float_buf, short *short_buf, unsigned int len)
 {
     for (int i = 0; (unsigned int) i <  NUMDEMOD; i++)


### PR DESCRIPTION
Up until now, the `--json` Flag lead to  the `--timestamp` and `--iso8601` flags being ignored.
I added a general function to add timestamps to a json if flags are set, which is called from the json generating parts of the demodulators. This way, it can be used by future json code of other modulators as well.