### PR TITLE
Add CCIR_FAST demodulator for fast (~20 ms) CCIR selcall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ set( SOURCES ${SOURCES}
 	demod_pzvei.c
 	demod_dzvei.c
 	demod_ccir.c
+	demod_ccir_fast.c
 	demod_eia.c
 	demod_eea.c
 	demod_ufsk12.c

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ multimon-ng is the successor of multimon. It decodes the following digital trans
 - FSK9600
 - DTMF
 - ZVEI1 ZVEI2 ZVEI3 DZVEI PZVEI
-- EEA EIA CCIR
+- EEA EIA CCIR CCIR_FAST
 - MORSE_CW
 - DUMPCSV X10 SCOPE SDL_SCOPE
 - GSC (Golay Sequential Code)

--- a/demod_ccir_fast.c
+++ b/demod_ccir_fast.c
@@ -1,0 +1,197 @@
+/*
+ *      demod_ccir_fast.c
+ *
+ *      Decoder for the "fast" CCIR selcall variant (~20 ms tones) that uses a
+ *      fixed RRRRR-S frame: five radio-ID tones followed by a single status
+ *      tone (0-15, hex tones A-F = 10-15). Consecutive identical digits are
+ *      sent as the CCIR repeat tone E (2110 Hz).
+ *
+ *      The stock CCIR decoder (selcall.c) integrates over a 40 ms window,
+ *      which is fine for standard ~100 ms CCIR tones but smears the 20 ms
+ *      tones here so that only the isolated (longer) status tone survives.
+ *      This decoder integrates over ~15 ms and segments the contiguous
+ *      address block by tone change, then frames RRRRR-S.
+ *
+ *      This program is free software; you can redistribute it and/or modify
+ *      it under the terms of the GNU General Public License as published by
+ *      the Free Software Foundation; either version 2 of the License, or
+ *      (at your option) any later version.
+ *
+ *      This program is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *      GNU General Public License for more details.
+ */
+
+#define SAMPLE_RATE 22050
+#define PHINC(x) ((x)*0x10000/SAMPLE_RATE)
+
+#include "multimon.h"
+#include "filter.h"
+#include <math.h>
+#include <string.h>
+
+/* Same 16 CCIR tones as demod_ccir.c. Index 14 (2110 Hz) is the repeat tone. */
+static const unsigned int ccir_fast_freq[16] = {
+    PHINC(1981), PHINC(1124), PHINC(1197), PHINC(1275),
+    PHINC(1358), PHINC(1446), PHINC(1540), PHINC(1640),
+    PHINC(1747), PHINC(1860), PHINC(2400), PHINC(930),
+    PHINC(2247), PHINC(991), PHINC(2110), PHINC(1055)
+};
+
+#define CCIR_FAST_REPEAT 14        /* tone index of the repeat tone (E) */
+
+#define BLOCKLEN  (SAMPLE_RATE/400)  /* ~2.5 ms blocks */
+#define NBLK      6                  /* integrate ~15 ms (must match multimon.h) */
+#define CONFIRM   2                  /* stable blocks (~5 ms) before committing */
+#define RESET_SIL 4                  /* silent blocks (~10 ms) that clear last tone */
+#define TIMEOUT_SIL 60               /* silent blocks (~150 ms) that end a frame */
+
+/* ---------------------------------------------------------------------- */
+
+static void ccir_fast_init(struct demod_state *s)
+{
+    memset(&s->l1.ccir_fast, 0, sizeof(s->l1.ccir_fast));
+    s->l1.ccir_fast.last_detected = -1;
+    s->l1.ccir_fast.last_committed = -1;
+    s->l1.ccir_fast.blkcount = BLOCKLEN;
+}
+
+/* Emit a completed frame, if it looks like a valid RRRRR-S message. */
+static void ccir_fast_flush(struct demod_state *s)
+{
+    struct l1_state_ccir_fast *st = &s->l1.ccir_fast;
+    int expanded[CCIR_FAST_MAXTONES];
+    int i, prev = -1;
+
+    if (st->frame_len >= 5) {
+        /* Expand the repeat tone: E means "same digit as the previous tone". */
+        for (i = 0; i < st->frame_len; i++) {
+            int t = st->frame[i];
+            if (t == CCIR_FAST_REPEAT && prev >= 0)
+                t = prev;
+            expanded[i] = t;
+            prev = t;
+        }
+
+        verbprintf(0, "CCIR_FAST: ");
+        for (i = 0; i < 5; i++)
+            verbprintf(0, "%1X", expanded[i]);
+        if (st->frame_len >= 6)
+            verbprintf(0, " status %d\n", expanded[5]);
+        else
+            verbprintf(0, " status ?\n");
+    }
+
+    st->frame_len = 0;
+    st->last_committed = -1;
+}
+
+/* Return the dominant tone index for the last NBLK blocks, or -1 if none
+ * dominates (silence, noise, or a tone boundary straddle). */
+static int ccir_fast_detect(struct demod_state *s)
+{
+    struct l1_state_ccir_fast *st = &s->l1.ccir_fast;
+    float tote = 0.0f, totte[16];
+    float en = 0.0f;
+    int i, j, idx = -1;
+
+    for (i = 0; i < NBLK; i++)
+        tote += st->energy[i];
+    for (i = 0; i < 16; i++) {
+        float re = 0.0f, im = 0.0f;
+        for (j = 0; j < NBLK; j++) {
+            re += st->tenergy[j][i];
+            im += st->tenergy[j][i + 16];
+        }
+        totte[i] = fsqr(re) + fsqr(im);
+    }
+    tote *= (NBLK * BLOCKLEN * 0.5f);
+
+    for (i = 0; i < 16; i++)
+        if (totte[i] > en) { en = totte[i]; idx = i; }
+    if (idx < 0)
+        return -1;
+    /* Require the winner to clearly dominate every other tone. */
+    en *= 0.1f;
+    for (i = 0; i < 16; i++)
+        if (i != idx && totte[i] > en)
+            return -1;
+    /* Require enough of the signal energy to sit in the matched tone. */
+    if ((tote * 0.4f) > totte[idx])
+        return -1;
+    return idx;
+}
+
+static void ccir_fast_process_block(struct demod_state *s)
+{
+    struct l1_state_ccir_fast *st = &s->l1.ccir_fast;
+    int d = ccir_fast_detect(s);
+
+    /* Slide the block history down by one. */
+    memmove(st->energy + 1, st->energy,
+            sizeof(st->energy) - sizeof(st->energy[0]));
+    st->energy[0] = 0.0f;
+    memmove(st->tenergy + 1, st->tenergy,
+            sizeof(st->tenergy) - sizeof(st->tenergy[0]));
+    memset(st->tenergy[0], 0, sizeof(st->tenergy[0]));
+
+    /* Track how long the current detection has been stable. */
+    if (d == st->last_detected)
+        st->stable_count++;
+    else {
+        st->last_detected = d;
+        st->stable_count = 1;
+    }
+
+    if (d >= 0) {
+        st->silence_blocks = 0;
+        if (st->stable_count >= CONFIRM && d != st->last_committed) {
+            if (st->frame_len < CCIR_FAST_MAXTONES)
+                st->frame[st->frame_len++] = d;
+            st->last_committed = d;
+        }
+    } else {
+        st->silence_blocks++;
+        /* A short gap lets an isolated tone re-trigger even if it repeats the
+         * last committed frequency (e.g. status == final address digit). */
+        if (st->silence_blocks == RESET_SIL)
+            st->last_committed = -1;
+        /* A long gap ends the message. */
+        if (st->silence_blocks == TIMEOUT_SIL && st->frame_len > 0)
+            ccir_fast_flush(s);
+    }
+}
+
+static void ccir_fast_demod(struct demod_state *s, buffer_t buffer, int length)
+{
+    struct l1_state_ccir_fast *st = &s->l1.ccir_fast;
+    const float *buf = buffer.fbuffer;
+    int i;
+
+    for (; length > 0; length--, buf++) {
+        float s_in = *buf;
+        st->energy[0] += fsqr(s_in);
+        for (i = 0; i < 16; i++) {
+            st->tenergy[0][i]      += COS(st->ph[i]) * s_in;
+            st->tenergy[0][i + 16] += SIN(st->ph[i]) * s_in;
+            st->ph[i] += ccir_fast_freq[i];
+        }
+        if (--st->blkcount <= 0) {
+            st->blkcount = BLOCKLEN;
+            ccir_fast_process_block(s);
+        }
+    }
+}
+
+static void ccir_fast_deinit(struct demod_state *s)
+{
+    /* Emit whatever complete frame is pending at end of stream. */
+    if (s->l1.ccir_fast.frame_len > 0)
+        ccir_fast_flush(s);
+}
+
+const struct demod_param demod_ccir_fast = {
+    "CCIR_FAST", true, SAMPLE_RATE, 0,
+    ccir_fast_init, ccir_fast_demod, ccir_fast_deinit
+};

--- a/multimon-ng.1
+++ b/multimon-ng.1
@@ -59,6 +59,8 @@ Selective call
 .IP \(bu 4
 CCIR
 .IP \(bu 4
+CCIR_FAST
+.IP \(bu 4
 EEA
 .IP \(bu 4
 EIA
@@ -98,6 +100,12 @@ ZVEI
 An arbitrary set of the above modes may run concurrently on the same input signal (provided the CPU power is sufficient), so you do not have to know in advance which mode is used. Note however that some modes might require modifications to the radio (especially the 9600 baud FSK and the POCSAG modes) to work properly.
 .PP
 AX.25 - Amateur Packet Radio protocol datagram format.
+.br
+CCIR_FAST - a fast (~20 ms/tone) CCIR selective-calling variant using a fixed
+five digit radio ID followed by a status tone (0-15). The standard CCIR decoder
+integrates over a window too long for these short tones and recovers only the
+status; this decoder tracks the fast tones, handles the repeat tone, and prints
+"CCIR_FAST: <id> status <n>".
 .br
 DTMF - Dual Tone Multi Frequency. Commonly used in in-band telephone dialing.
 .br
@@ -221,7 +229,7 @@ Format output as JSON. Supported by the following demodulators:
 DTMF, EAS, FLEX, POCSAG. (Other demodulators will silently ignore this flag.)
 .PP
 Where <demod> is one of:
-POCSAG512 POCSAG1200 POCSAG2400 FLEX FLEX_NEXT GSC EAS UFSK1200 CLIPFSK FMSFSK AFSK1200 AFSK2400 AFSK2400_2 AFSK2400_3 HAPN4800 FSK9600 DTMF ZVEI1 ZVEI2 ZVEI3 DZVEI PZVEI EEA EIA CCIR MORSE_CW DUMPCSV X10 SCOPE SDL_SCOPE
+POCSAG512 POCSAG1200 POCSAG2400 FLEX FLEX_NEXT GSC EAS UFSK1200 CLIPFSK FMSFSK AFSK1200 AFSK2400 AFSK2400_2 AFSK2400_3 HAPN4800 FSK9600 DTMF ZVEI1 ZVEI2 ZVEI3 DZVEI PZVEI EEA EIA CCIR CCIR_FAST MORSE_CW DUMPCSV X10 SCOPE SDL_SCOPE
 .br
 The \-a and \-s options may be given multiple times to specify the desired list of demodulators.
 .SH EXAMPLE

--- a/multimon.h
+++ b/multimon.h
@@ -226,6 +226,20 @@ struct demod_state {
             int timeout;
         } selcall;
 
+#define CCIR_FAST_MAXTONES 16
+        struct l1_state_ccir_fast {
+            unsigned int ph[16];
+            float energy[6];        /* NBLK block history */
+            float tenergy[6][32];
+            int blkcount;
+            int last_detected;
+            int stable_count;
+            int last_committed;
+            int silence_blocks;
+            int frame[CCIR_FAST_MAXTONES];
+            int frame_len;
+        } ccir_fast;
+
         struct l1_state_morse {
             uint64_t current_sequence;
             int_fast16_t threshold_ctr;
@@ -321,6 +335,7 @@ extern const struct demod_param demod_pzvei;
 extern const struct demod_param demod_eea;
 extern const struct demod_param demod_eia;
 extern const struct demod_param demod_ccir;
+extern const struct demod_param demod_ccir_fast;
 
 extern const struct demod_param demod_morse;
 
@@ -349,7 +364,7 @@ extern const struct demod_param demod_sdl_scope;
 #define ALL_DEMOD &demod_poc5, &demod_poc12, &demod_poc24, &demod_flex, &demod_flex_next, &demod_gsc, &demod_eas, &demod_ufsk1200, &demod_clipfsk, &demod_fmsfsk, \
     &demod_afsk1200, &demod_afsk2400, &demod_afsk2400_2, &demod_afsk2400_3, &demod_hapn4800, \
     &demod_fsk9600, &demod_dtmf, &demod_zvei1, &demod_zvei2, &demod_zvei3, &demod_dzvei, \
-    &demod_pzvei, &demod_eea, &demod_eia, &demod_ccir, &demod_morse, &demod_dumpcsv, &demod_x10 SCOPE_DEMOD SDL_SCOPE_DEMOD
+    &demod_pzvei, &demod_eea, &demod_eia, &demod_ccir, &demod_ccir_fast, &demod_morse, &demod_dumpcsv, &demod_x10 SCOPE_DEMOD SDL_SCOPE_DEMOD
 
 
 /* ---------------------------------------------------------------------- */


### PR DESCRIPTION
## What

Adds a new `CCIR_FAST` demodulator (`-a CCIR_FAST`) for a fast variant of CCIR
selective calling that uses **~20 ms tones** and a fixed **five-digit radio ID +
status tone** frame.

## Why

The existing `CCIR` decoder (via `selcall.c`) integrates over a ~40 ms window,
which is appropriate for standard ~100 ms CCIR tones. Some fleet selcall systems
send much faster ~20 ms tones packed back-to-back. With those, the 40 ms window
almost always straddles two adjacent tones and rejects them, so the decoder
recovers only the single longer, isolated status tone at the end of each message.

## How

`CCIR_FAST` is self-contained (`demod_ccir_fast.c`) and reuses the standard 16
CCIR tone frequencies:

- Detects tones with a **15 ms Goertzel window stepped every 2.5 ms**, so each
  20 ms tone yields several clean detections (decoupling the time step from the
  integration length is what makes the short tones recoverable).
- Segments the contiguous address block by **tone change** (the CCIR repeat tone
  guarantees no two identical adjacent tones) and commits each tone once.
- Two silence thresholds: a short one clears the last tone so an isolated status
  tone re-triggers even when it repeats the final address digit; a long one ends
  the message.
- Expands the **repeat tone E** (`= previous digit`) and frames the first five
  tones as the radio ID plus a status tone (0-15, hex tones A-F = 10-15).

Output:

```
CCIR_FAST: 19190 status 1
```

## Testing

- Verified against a reference decoder on recorded off-air captures (matched on
  every message across multiple files, exercising the repeat tone and multiple
  status values).
- Confirmed live end-to-end from an RTL-SDR (`rtl_fm ... | multimon-ng -a CCIR_FAST`).

The existing `CCIR` mode is untouched. Docs (`multimon-ng.1`, `README.md`) updated.